### PR TITLE
Fix 64-bit stack pointer usage in scheduler

### DIFF
--- a/kernel/src/scheduler.S
+++ b/kernel/src/scheduler.S
@@ -352,9 +352,9 @@ ring3Return:
     mov rbx, [mp_isrSavedRIP + rax * 8]
     mov [rsp], rbx
     mov rbx, [mp_isrSavedCS + rax * 8]
-    mov [esp + 8], rbx
+    mov [rsp + 8], rbx
     mov rbx, [mp_isrSavedRSP + rax * 8]
-    mov [esp + 16], rbx
+    mov [rsp + 16], rbx
     mov ebx, [mp_isrSavedSS + rax * 8]
     mov [rsp + 24], rbx
     mov bl,[mp_SchedulerTaskSwitched + rax]			# mp_SchedulerTaskSwitched is a byte array, 1 byte per core


### PR DESCRIPTION
## Summary
- fix ring 3 return stack writes to use `rsp` instead of `esp`

## Testing
- `make -C kernel` *(fails: Please run the ./get-deps script first)*
- `./kernel/get-deps` *(fails: unable to access github.com)*

------
https://chatgpt.com/codex/tasks/task_e_68729ab5ca148322bb86b48dd4519b99