### PR TITLE
Add spinlock for serial output

### DIFF
--- a/kernel/src/serial.c
+++ b/kernel/src/serial.c
@@ -1,7 +1,25 @@
 #include "io.h"
 #include "time.h"
 
+static volatile int serial_lock = 0;
+
+static inline void serial_lock_acquire() {
+    while (__sync_lock_test_and_set(&serial_lock, 1)) {
+        /* spin */
+    }
+}
+
+static inline void serial_lock_release() {
+    __sync_lock_release(&serial_lock);
+}
+
+static void write_serial_unlocked(int port, char a) {
+    outb(port, a);
+    __asm__("nop\nnop\nnop\n");
+}
+
 int init_serial(int port) {
+    serial_lock_acquire();
     outb(COM1 + 1, 0x00); // Disable all interrupts
     outb(COM1 + 3, 0x80); // Enable DLAB (set baud rate divisor)
     outb(COM1 + 0, 0x03); // Divisor low byte (38400 baud)
@@ -9,31 +27,34 @@ int init_serial(int port) {
     outb(COM1 + 3, 0x03); // 8 bits, no parity, one stop bit
     outb(COM1 + 2, 0xC7); // Enable FIFO, clear them, 14-byte threshold
     outb(COM1 + 4, 0x0B); // IRQs enabled, RTS/DSR set
-	// Check if serial is faulty (i.e: not same byte as sent)
-	if(inb(port + 0) != 0xAE) {
-		return 1;
-	}
+    // Check if serial is faulty (i.e: not same byte as sent)
+    if (inb(port + 0) != 0xAE) {
+        serial_lock_release();
+        return 1;
+    }
 
-	// If serial is not faulty set it in normal operation mode
-	// (not-loopback with IRQs enabled and OUT#1 and OUT#2 bits enabled)
-	outb(port + 4, 0x0F);
-	return 0;
+    // If serial is not faulty set it in normal operation mode
+    // (not-loopback with IRQs enabled and OUT#1 and OUT#2 bits enabled)
+    outb(port + 4, 0x0F);
+    serial_lock_release();
+    return 0;
 }
 
 int is_transmit_empty(int port) {
-   return inb(port + 5) & 0x20;
+    return inb(port + 5) & 0x20;
 }
 
 void write_serial(int port, char a) {
-   //while (is_transmit_empty(port) == 0){}
-   outb(port,a);
-   __asm__("nop\nnop\nnop\n");
-   //wait(0);
+    serial_lock_acquire();
+    write_serial_unlocked(port, a);
+    serial_lock_release();
 }
 
 // Implemented to handle processing a string and writing all the bytes via write_serial()
 void serial_print_string(const char *message) {
+    serial_lock_acquire();
     for (const char *c = message; *c; c++) {
-        write_serial(COM1,*c);
+        write_serial_unlocked(COM1, *c);
     }
+    serial_lock_release();
 }

--- a/kernel/src/serial.c
+++ b/kernel/src/serial.c
@@ -13,7 +13,7 @@ static inline void serial_lock_release() {
     __sync_lock_release(&serial_lock);
 }
 
-static void write_serial_unlocked(int port, char a) {
+static inline void serial_write_char(int port, char a) {
     outb(port, a);
     __asm__("nop\nnop\nnop\n");
 }
@@ -46,7 +46,7 @@ int is_transmit_empty(int port) {
 
 void write_serial(int port, char a) {
     serial_lock_acquire();
-    write_serial_unlocked(port, a);
+    serial_write_char(port, a);
     serial_lock_release();
 }
 
@@ -54,7 +54,7 @@ void write_serial(int port, char a) {
 void serial_print_string(const char *message) {
     serial_lock_acquire();
     for (const char *c = message; *c; c++) {
-        write_serial_unlocked(COM1, *c);
+        serial_write_char(COM1, *c);
     }
     serial_lock_release();
 }


### PR DESCRIPTION
## Summary
- Protect serial writes with a global spinlock.
- Hold the lock across serial_print_string's character loop to avoid interleaving.
- Guard init_serial and write_serial with the same lock.

## Testing
- `make kernel` *(fails: unable to access 'https://github.com/osdev0/freestnd-c-hdrs-0bsd.git/' - CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e4ac2c54832286f5c069d93948bc