### PR TITLE
Fix serial log format specifiers

### DIFF
--- a/kernel/src/serial_logging.c
+++ b/kernel/src/serial_logging.c
@@ -74,12 +74,12 @@ void printd(__uint128_t debug_level, const char *fmt, ...) {
 	//  if this code is enabled. :-(
 	{
     	char print_buf2[2048];
-        snprintf(print_buf2, sizeof(print_buf2), "%llu (0x%04llx) AP%u: %s", tick_count, threadID, core, print_buf);
+        snprintf(print_buf2, sizeof(print_buf2), "%lu (0x%04llx) AP%u: %s", tick_count, threadID, core, print_buf);
     	serial_print_string(print_buf2);
 	}	
 #else
     char print_buf2[2048];
-    snprintf(print_buf2, sizeof(print_buf2), "%llu (0x%04llx) AP%u: %s", tick_count, threadID, core, print_buf);
+    snprintf(print_buf2, sizeof(print_buf2), "%lu (0x%04llx) AP%u: %s", tick_count, threadID, core, print_buf);
     serial_print_string(print_buf2);
 #endif
 }


### PR DESCRIPTION
## Summary
- Use 64-bit format specifiers for tick count and thread ID in serial logging

## Testing
- `QEMUFLAGS="-m 512M -smp 2 -no-reboot -serial stdio -display none" ./run` *(fails: fatal: unable to access 'https://github.com/limine-bootloader/limine.git/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e4b553f08322983e771ae498d32d