### PR TITLE
Use 64-bit tick counter and drop obsolete lock

### DIFF
--- a/kernel/src/strings/sprintf.c
+++ b/kernel/src/strings/sprintf.c
@@ -15,10 +15,8 @@
 #include "strings.h"
 #include "memset.h"
 #include "strlen.h"
-#include "printd.h"
 
-extern uint32_t* kTicksSinceStart;
-volatile uint32_t lock_mp_printd;
+extern volatile uint64_t kTicksSinceStart;
 
 static int skip_atoi(const char **s)
 {


### PR DESCRIPTION
## Summary
- switch sprintf's tick counter declaration to `volatile uint64_t`
- remove unused `lock_mp_printd` variable

## Testing
- `make -C kernel` *(fails: Please run the ./get-deps script first)*
- `./kernel/get-deps` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e4c8ff648322b6d0efc23659e6da