### PR TITLE
Ring-3 bring-up: first true user-mode tasks with working SYSCALL/SYSRET

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,15 +1,28 @@
-# GDB initialization for os64 kernel debugging
+# GDB initialization for os64 kernel debugging (CLI gdb).
+# VS Code does NOT read this file — its equivalent lives in
+# .vscode/launch.json setupCommands; the shared logic is in
+# utility/os64_symbols.gdb so both stay in sync.
 set architecture i386:x86-64
 target remote localhost:1234
 
 # Load kernel symbols
 symbol-file kernel/bin/os64_kernel
 
-# Add test_elf symbols at its load address
-add-symbol-file kernel/bin/test_elf 0x400000
+# Shared settings + per-app symbol autoloader (see comments in the file)
+source utility/os64_symbols.gdb
+
+# ── Breakpoints in user programs: use hbreak ─────────────────────────────────
+# Software breakpoints (int3) in app code misbehave twice over: the target
+# page is demand-paged (not yet mapped when the breakpoint is inserted), and
+# insertion happens under whatever CR3 is current (usually not the app's).
+# Hardware breakpoints match the linear address in ANY address space and need
+# no memory write:
+#     hbreak syscall_smoke.c:_start     (goes pending until symbols autoload)
+#     hbreak *0x400050
+# Note x86 has only 4 hardware breakpoint slots.
 
 # Useful breakpoints (commented out - uncomment as needed)
-# break *0x400000
+# hbreak *0x400000
 # break handle_page_fault
 # break task_exit
 # break vma_resolve_backing_page

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -13,11 +13,12 @@ override USER_VARIABLE = $(if $(filter $(origin $(1)),default undefined),$(eval 
 
 # Define the base QEMU flags
 # -smp 2 
-QEMU_BASE_FLAGS = -m 8g -no-reboot -smp 2\
+QEMU_BASE_FLAGS = -m 8g -no-reboot -smp 2 \
                   -serial file:qemu_com1.log \
                   -monitor $(shell echo telnet:127.0.0.1:55555,server,nowait) \
-				  -D qemu_debug.log 
-				  
+				  -d $(shell echo int,cpu_reset,pcall,guest_errors)
+#				  -D qemu_debug.log 
+
 # Disk image configuration
 DISK_IMAGE ?= $(CURDIR)/disk/os64.img
 DISK_OFFSET ?= 1048576
@@ -130,6 +131,8 @@ disk-populate: disk-init kernel
 	mcopy -o -i $(DISK_IMAGE)@@$(DISK_OFFSET) kernel/bin/test_elf ::/bin/test_elf
 	mcopy -o -i $(DISK_IMAGE)@@$(DISK_OFFSET) kernel/bin/arg_echo ::/bin/arg_echo
 	mcopy -o -i $(DISK_IMAGE)@@$(DISK_OFFSET) kernel/bin/dyn_consumer ::/bin/dyn_consumer
+	mcopy -o -i $(DISK_IMAGE)@@$(DISK_OFFSET) kernel/bin/syscall_smoke ::/bin/syscall_smoke
+	mcopy -o -i $(DISK_IMAGE)@@$(DISK_OFFSET) kernel/bin/exit_by_return ::/bin/exit_by_return
 	mcopy -o -i $(DISK_IMAGE)@@$(DISK_OFFSET) kernel/bin/libtest.so ::/lib/libtest.so
 	mcopy -o -i $(DISK_IMAGE)@@$(DISK_OFFSET) kernel/test/partition_info.txt ::/partition_info
 

--- a/kernel/GNUmakefile
+++ b/kernel/GNUmakefile
@@ -31,7 +31,12 @@ $(call USER_VARIABLE,AR,x86_64-elf-ar)
 $(call USER_VARIABLE,LD,x86_64-elf-ld)
 
 # User controllable C flags.
-$(call USER_VARIABLE,CFLAGS,-mno-red-zone -g -O0 -I include -pipe)
+# -mno-mmx/-mno-sse/-mno-sse2: the kernel must not emit SIMD — the scheduler
+# does not save/restore FPU/XMM state on context switch, and CR4.OSFXSR is
+# off anyway (any SSE instruction is #UD; the syscall dispatcher's array
+# zeroing found this the hard way).  Revisit when an FPU-state slice adds
+# fxsave/xsave switching for userland.
+$(call USER_VARIABLE,CFLAGS,-mno-red-zone -mno-mmx -mno-sse -mno-sse2 -g -O0 -I include -pipe)
 
 # User controllable C preprocessor flags. We set none by default.
 $(call USER_VARIABLE,CPPFLAGS,)
@@ -110,7 +115,7 @@ override SRC_CFILES := $(filter-out src/asm-offsets.c,$(shell find src -type f -
 # by their own sub-Makefiles via the test-elf/test-shlib targets below, with
 # their own -fpie/-fPIC flags) — they are not kernel test code and must not
 # be compiled into the kernel binary, unlike test_main.c/test_vma_*.c.
-override TEST_CFILES := $(filter-out test/elf/dyn_consumer.c test/elf/arg_echo.c test/shlib/libtest.c,$(shell find test -type f -name '*.c' 2>/dev/null | LC_ALL=C sort))
+override TEST_CFILES := $(filter-out test/elf/dyn_consumer.c test/elf/arg_echo.c test/elf/syscall_smoke.c test/elf/exit_by_return.c test/shlib/libtest.c,$(shell find test -type f -name '*.c' 2>/dev/null | LC_ALL=C sort))
 override CFILES := $(SRC_CFILES) $(TEST_CFILES)
 override ASFILES := $(shell find src -type f -name '*.S' | LC_ALL=C sort)
 override NASMFILES := $(shell find src -type f -name '*.asm' | LC_ALL=C sort)

--- a/kernel/include/BasicRenderer.h
+++ b/kernel/include/BasicRenderer.h
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include "limine.h"
 #include "video.h"
 
@@ -50,6 +51,7 @@ extern BasicRenderer kRenderer;
 void init_renderer(BasicRenderer *basicrenderer, struct Framebuffer *framebuffer, struct PSF1_FONT *psf1_font);
 void moveto(BasicRenderer *basicrenderer, unsigned int x, unsigned int y);
 void print(const char* str);
+void print_n(const char* str, size_t length);
 int printf(const char *fmt, ...);
 void put_char(BasicRenderer *basicrenderer, char chr, unsigned int xOff, unsigned int yOff);
 void clear(BasicRenderer *basicrenderer, uint32_t color, bool resetCursor);

--- a/kernel/include/gdt.h
+++ b/kernel/include/gdt.h
@@ -5,10 +5,18 @@
 #include <stdbool.h>
 
 #define GDT_ENTRIES 128
+// Entry ORDER here is dictated by the SYSCALL/SYSRET hardware contract, not taste:
+//   SYSCALL loads CS = STAR[47:32] and SS = STAR[47:32] + 8
+//     -> kernel DATA must sit immediately after kernel CODE.
+//   SYSRETQ loads CS = STAR[63:48] + 16 and SS = STAR[63:48] + 8
+//     -> user CODE must sit immediately after user DATA (yes, the opposite
+//        order from the kernel pair — the +16 skips over a 32-bit user code
+//        slot that 64-bit-only os64 doesn't need, but the spacing is fixed).
+// smp_core.c builds STAR from these and static-asserts both orderings.
 #define GDT_KERNEL_CODE_ENTRY 5
 #define GDT_KERNEL_DATA_ENTRY 6
-#define GDT_USER_CODE_ENTRY   7
-#define GDT_USER_DATA_ENTRY   8
+#define GDT_USER_DATA_ENTRY   7
+#define GDT_USER_CODE_ENTRY   8
 #define GDT_FIRST_TSS_ENTRY   20
 #define TSS_SELECTOR (GDT_FIRST_TSS_ENTRY << 3)
 // Helper define for TSS

--- a/kernel/include/msr.h
+++ b/kernel/include/msr.h
@@ -3,10 +3,14 @@
 
 #include <stdint.h>
 
+#define EFER_MSR 0xC0000080
 #define STAR_MSR 0xC0000081
 #define LSTAR_MSR 0xC0000082
 #define CSTAR_MSR 0xC0000083
 #define SFMASK_MSR 0xC0000084
+
+// EFER bits os64 cares about
+#define EFER_SCE (1ULL << 0)   // SYSCALL/SYSRET enable — without it, `syscall` is #UD
 
 uint64_t rdmsr64(unsigned index);
 void wrmsr64(unsigned index, uint64_t val);

--- a/kernel/include/scheduler.h
+++ b/kernel/include/scheduler.h
@@ -33,7 +33,6 @@
 	void scheduler_submit_new_task(task_t *newTask);
 	void scheduler_change_thread_queue(thread_t* thread, eThreadState newState);
 	void scheduler_reap_zombie_thread(thread_t *thread);
-	void scheduler_yield(core_local_storage_t *cls);
 	void scheduler_trigger(core_local_storage_t *cls);
 	void scheduler_wake_isleep_task(task_t *task);
     bool in_scheduler_context(void);

--- a/kernel/include/smp.h
+++ b/kernel/include/smp.h
@@ -72,6 +72,13 @@ typedef struct
 	void *cikc_saved_arg;
 	uint64_t cikc_saved_cr3;
 	uint64_t cikc_saved_rsp;
+
+	// syscall_Enter's stash for the user RSP between "SYSCALL landed" and "we're
+	// on the kernel stack" (syscall.S).  GS-relative so the entry stub never has
+	// to touch the user stack (a bogus ring-3 RSP must not be able to fault the
+	// kernel).  Safe as a single per-core slot because SFMASK clears IF on entry:
+	// nothing can preempt between the store and the reload.
+	uint64_t syscall_user_rsp;
 } core_local_storage_t;
 
 

--- a/kernel/include/smp_offsets.h
+++ b/kernel/include/smp_offsets.h
@@ -3,6 +3,7 @@
 
 #define CLS_KERNEL_RSP0_OFFSET 0x50
 #define CLS_KERNEL_INTERRUPT_STACK_TOP_OFFSET 0x68
+#define CLS_SYSCALL_USER_RSP_OFFSET 0x90
 
 #ifndef __ASSEMBLER__
 #include <stddef.h>
@@ -11,6 +12,8 @@ _Static_assert(CLS_KERNEL_RSP0_OFFSET == offsetof(core_local_storage_t, kernel_r
                "CLS_KERNEL_RSP0_OFFSET mismatch");
 _Static_assert(CLS_KERNEL_INTERRUPT_STACK_TOP_OFFSET == offsetof(core_local_storage_t, kernel_interrupt_stack_top),
                "CLS_KERNEL_INTERRUPT_STACK_TOP_OFFSET mismatch");
+_Static_assert(CLS_SYSCALL_USER_RSP_OFFSET == offsetof(core_local_storage_t, syscall_user_rsp),
+               "CLS_SYSCALL_USER_RSP_OFFSET mismatch");
 #endif
 
 #endif

--- a/kernel/include/syscall.h
+++ b/kernel/include/syscall.h
@@ -15,8 +15,21 @@ typedef uint64_t (*syscall_func_t)(
 typedef struct {
     syscall_func_t func;
     const char* name;
+    // DANGER: leave this false unless the handler switches STACKS too.  The
+    // dispatcher runs on the thread's syscall kernel stack — a task-local VA
+    // that kKernelPML4 does not map — so flipping CR3 under a C handler
+    // triple-faults on the next stack access.  The user CR3 already maps the
+    // full kernel upper half; see the syscall_table comment in syscall.c.
     bool needs_cr3_switch;
-    bool needs_user_copy;
+    // Bit i set = arg i is a USER-SPACE POINTER the dispatcher should
+    // range-check before the handler runs.  A mask (not a blanket "check all
+    // six") because unused argument registers carry ring-3 garbage — and
+    // right after a previous syscall that garbage is kernel addresses our own
+    // clobber convention left behind, which a blanket >= kHHDMOffset scan
+    // "helpfully" rejects.  (write() was the first casualty: R10 held a
+    // leftover kernel pointer from yield(), so a perfectly valid write got
+    // SYSCALL_RESULT_BAD_USER_DATA without the handler ever running.)
+    uint8_t user_ptr_arg_mask;
     bool trace_enabled;
 } syscall_entry_t;
 
@@ -33,12 +46,13 @@ uint64_t _syscall_dispatch(
 );
 
 // A macro to help define syscalls in syscall_table[]
-#define SYSCALL_DEFINE(NUM, NAME, FN, CR3, COPY) \
-    [NUM] = { .func = FN, .name = NAME, .needs_cr3_switch = CR3, .needs_user_copy = COPY, .trace_enabled = false }
+// PTRMASK: bitmask of which args are user pointers (see user_ptr_arg_mask).
+#define SYSCALL_DEFINE(NUM, NAME, FN, CR3, PTRMASK) \
+    [NUM] = { .func = FN, .name = NAME, .needs_cr3_switch = CR3, .user_ptr_arg_mask = PTRMASK, .trace_enabled = false }
 
 // Optional: variant with trace flag
-#define SYSCALL_DEFINE_EX(NUM, NAME, FN, CR3, COPY, TRACE) \
-    [NUM] = { .func = FN, .name = NAME, .needs_cr3_switch = CR3, .needs_user_copy = COPY, .trace_enabled = TRACE }
+#define SYSCALL_DEFINE_EX(NUM, NAME, FN, CR3, PTRMASK, TRACE) \
+    [NUM] = { .func = FN, .name = NAME, .needs_cr3_switch = CR3, .user_ptr_arg_mask = PTRMASK, .trace_enabled = TRACE }
 
 void switch_to_kernel_cr3(void);
 void restore_user_cr3(void);

--- a/kernel/include/syscall_numbers.h
+++ b/kernel/include/syscall_numbers.h
@@ -1,0 +1,23 @@
+#ifndef SYSCALL_NUMBERS_H
+#define SYSCALL_NUMBERS_H
+
+// os64 syscall numbers — shared between C (syscall table) and assembly (the
+// ring-3 exit trampoline template in task_exit_asm.S), so this header must
+// stay preprocessor-only: bare #defines, no typedefs, no prototypes.
+//
+// os64 syscall convention (ours, not Linux's — numbers and semantics are free
+// to diverge; see syscall.S for the register contract):
+//   RAX = syscall number, args in RDI, RSI, RDX, R10, R8, R9, result in RAX.
+
+#define SYSCALL_YIELD      0
+#define SYSCALL_DEBUG_LOG  1
+#define SYSCALL_EXIT       2
+#define SYSCALL_WRITE      3
+
+// Well-known handles accepted by SYSCALL_WRITE until a real per-task handle
+// table exists.  1/2 mirror the "stdout/stderr" convention because it is a
+// genuinely good one — both currently reach the console.
+#define SYSCALL_HANDLE_CONSOLE_OUT  1
+#define SYSCALL_HANDLE_CONSOLE_ERR  2
+
+#endif

--- a/kernel/include/task.h
+++ b/kernel/include/task.h
@@ -17,6 +17,10 @@
 //Virtual address of the environment pointers
 #define TASK_ENVP_VIRT 0x6f010000
 #define TASK_ENV_VIRT 0x6f006000
+//Virtual address of the ring-3 exit trampoline page (read-only+exec, user).
+//Seeded as _start's return address so a plain `ret` becomes an exit syscall.
+//See task_setup_ring3_exit_path() and the template in task_exit_asm.S.
+#define TASK_EXIT_TRAMPOLINE_VIRT 0x6f020000
 // Task-specific memory allocation base addresses (lower half)
 #define USER_TASK_MEMORY_BASE   0x10000000  // 256MB - for user task allocations
 #define KERNEL_TASK_MEMORY_BASE 0x40000000  // 1GB - for kernel task allocations
@@ -78,6 +82,11 @@
         bool kernelTask;
         struct tm startTime, endTime;
         uint64_t entryPoint;
+        // ELF load bias: 0 for static (ET_EXEC) programs, the randomized/fixed
+        // relocation offset for PIE (ET_DYN) ones.  Consumed by the GDB
+        // symbol-autoload hook (debug_task_loaded) so .gdbinit can offset the
+        // program's debug info to where the image actually landed.
+        uint64_t loadBias;
         int argc;
         char** argv;
         struct rusage usage;

--- a/kernel/include/thread.h
+++ b/kernel/include/thread.h
@@ -15,7 +15,13 @@
 #define THREAD_USER_STACK_INITIAL_VIRT_ADDRESS THREAD_USER_STACK_VIRTUAL_START + THREAD_USER_STACK_SIZE - 8
 
 #define THREAD_KERNEL_STACK_VIRTUAL_START 0x20000
-#define THREAD_KERNEL_STACK_SIZE  0xFFFF	//64k kernel stack
+// MUST be a page multiple: the stack TOP (base + size) seeds RSP0/regs.RSP,
+// and an odd size makes every kernel RSP in the OS odd.  That interacts
+// fatally with the CPU's 16-byte RSP alignment on interrupt delivery — up to
+// 15 bytes of live stack silently vanish per preemption.  (This was 0xFFFF,
+// "64k" minus one byte; found during ring-3 bring-up as byte-SHIFTED values
+// popping off resumed stacks.)
+#define THREAD_KERNEL_STACK_SIZE  0x10000	//64k kernel stack
 #define THREAD_KERNEL_STACK_INITIAL_VIRT_ADDRESS THREAD_KERNEL_STACK_VIRTUAL_START + THREAD_KERNEL_STACK_SIZE - 8
 
 #define THREAD_VIRTUAL_STRUCT_ADDRESS 0xF0000000

--- a/kernel/src/BasicRenderer.c
+++ b/kernel/src/BasicRenderer.c
@@ -1,5 +1,6 @@
 #include "BasicRenderer.h"
 #include "sprintf.h"
+#include "strings/strlen.h"
 #include "memset.h"
 #include "video.h"
 #include "memcpy.h"
@@ -151,10 +152,13 @@ int printf(const char *fmt, ...)
 	return printed;
 }
 
-void print(const char* str) {
+// Length-bounded console output — the worker behind print().  Exists so the
+// write() syscall can push exact byte counts (which may legally contain NUL
+// bytes) through the same cursor/wrap/scroll logic instead of duplicating it.
+void print_n(const char* str, size_t length) {
     const char *chr = str;
     BasicRenderer *basicrenderer = &kRenderer;
-    while (*chr != 0) {
+    for (size_t i = 0; i < length; i++, chr++) {
         switch (*chr) {
             case '\n':
                 basicrenderer->cursor_position.x = 0;
@@ -180,9 +184,11 @@ void print(const char* str) {
             scroll_framebuffer_full(basicrenderer);
             basicrenderer->cursor_position.y = basicrenderer->framebuffer->height - 16;
         }
-
-        chr++;
     }
+}
+
+void print(const char* str) {
+    print_n(str, strlen(str));
 }
 
 void put_char(BasicRenderer *basicrenderer, char chr, unsigned int xOff, unsigned int yOff)

--- a/kernel/src/driver/system/exceptions/simple_exceptions.c
+++ b/kernel/src/driver/system/exceptions/simple_exceptions.c
@@ -3,6 +3,7 @@
 #include "panic.h"
 #include "BasicRenderer.h"
 #include "serial_logging.h"
+#include "sprintf.h"
 #include "smp_core.h"
 #include "task.h"
 #include "CONFIG.h"
@@ -97,28 +98,45 @@ void dump_stack_trace(uint64_t rip)
 	}
 }
 
+// Emit a line to BOTH the screen and the serial port.  Exceptions must be
+// diagnosable from either — a #GP that only ever appears on the framebuffer
+// is invisible to headless/CI runs.  Serial output goes DIRECTLY through
+// serial_print_string, bypassing the printd ring buffer entirely: this core
+// is about to cli/hlt, so anything left in the buffer depends on another
+// core's logd/kworker still being alive to drain it (and logd_thread(false)
+// is only a try-lock — it can silently drain nothing).  A panic path must
+// not have dependencies.
+#define EXCEPTION_PRINT(fmt, ...) do { \
+        printf(fmt, ##__VA_ARGS__); \
+        char _exc_line[512]; \
+        snprintf(_exc_line, sizeof(_exc_line), fmt, ##__VA_ARGS__); \
+        serial_print_string(_exc_line); \
+    } while (0)
+
 void exception_panic(const char* message, uint64_t rip, uint64_t error_code) {
     core_local_storage_t* core = get_core_local_storage();
 
-    printf("\n>>> EXCEPTION PANIC: %s <<<                      \n", message);  // 🛠 FIXED: Actually print the message!
-    printf(">>> AP %lu (Thread 0x%08x) <<<                        \n", core->apic_id, core->threadID);
-    printf(">>> Faulting instruction: 0x%016lx <<<             \n", rip);
-    
+    EXCEPTION_PRINT("\n>>> EXCEPTION PANIC: %s <<<                      \n", message);
+    EXCEPTION_PRINT(">>> AP %lu (Thread 0x%08x) <<<                        \n", core->apic_id, core->threadID);
+    EXCEPTION_PRINT(">>> Faulting instruction: 0x%016lx <<<             \n", rip);
+
     if (error_code != 0xFFFFFFFFFFFFFFFF) {
-        printf(">>> Error Code: 0x%lx <<<                          \n", error_code);
+        EXCEPTION_PRINT(">>> Error Code: 0x%lx <<<                          \n", error_code);
     }
     if (core->currentThread) {
 		task_t *task = (task_t*)core->currentThread->ownerTask;
 
-        printf(">>> Excepting Task: %s <<<                         \n", task->path);
+        EXCEPTION_PRINT(">>> Excepting Task: %s <<<                         \n", task->path);
     } else {
-        printf(">>> No current task (core likely idle) <<<         \n");
+        EXCEPTION_PRINT(">>> No current task (core likely idle) <<<         \n");
     }
 
-	// **Log it only if logging is initialized**
+	// Best-effort drain of the printd ring buffer too, so the log context
+	// LEADING UP to the exception makes it out with us.  Try-lock inside —
+	// if another core holds the drain lock this does nothing, which is why
+	// the exception report itself went directly to serial above.
 	if (kLoggingInitialized) {
-		printd(DEBUG_EXCEPTIONS, "EXCEPTION: %s (AP %lu, Thread %lu, RIP: 0x%016lx, Error Code: 0x%lx)\n",
-				message, core->apic_id, core->threadID, rip, error_code);
+		logd_thread(false);
 	}
 
 	while (1) { __asm__ volatile ("cli\nhlt\n"); }
@@ -255,10 +273,18 @@ void handle_page_fault(uint64_t cr2, uint64_t error_code, uint64_t rip)
     {
         // Page is present but the access was denied and this VMA is not CoW.
         // This is a genuine protection violation, not a recoverable fault.
+        // Decode the error bits into the panic message rather than assuming
+        // write-to-read-only: a USER instruction fetch through intermediate
+        // tables lacking PAGE_USER lands here too (that exact fault, error
+        // 0x15, is how ring-3 bring-up found the paging_map_page U/S bug),
+        // and a wrong message sends the reader hunting in the wrong place.
         printd(DEBUG_EXCEPTIONS, "Protection violation at RIP=0x%016lx, CR2=0x%016lx\n", rip, cr2);
         log_page_fault_bits(error_code);
         dump_stack_trace(rip);
-        panic("Paging exception: protection violation (write to read-only non-CoW page)");
+        panic("Paging exception: protection violation (%s access, %s mode, error=0x%lx) on a present non-CoW page",
+              (error_code & 0x10) ? "instruction-fetch" : ((error_code & 0x2) ? "write" : "read"),
+              (error_code & 0x4) ? "user" : "supervisor",
+              error_code);
     }
 
     // Demand page fault: page is not present yet.

--- a/kernel/src/gdt.c
+++ b/kernel/src/gdt.c
@@ -14,7 +14,21 @@ void set_gdt_entry_additional_for_system_descriptors(gdt_entry_additional_t* add
     additional_entry->reserved = 0;                      // Reserved, must be 0
 }
 
-void set_gdt_entry(gdt_entry_t* gdt_table, int entryNo, uint64_t base, uint32_t limit, uint8_t access, uint8_t flags, uint8_t isSystem) 
+// sFlag is the x86 descriptor S flag, exactly as the GDT_S_* defines read:
+//   GDT_S_SYSTEM_SEGMENT (0)    — system descriptor (TSS/LDT).  These are
+//                                 16 bytes in long mode, so the upper half of
+//                                 the base is written into gdt_table[entryNo+1]
+//                                 which MUST be reserved for that purpose.
+//   GDT_S_CODE_DATA_SEGMENT (1) — ordinary 8-byte code/data descriptor; the
+//                                 S bit is OR'd into access and entryNo+1 is
+//                                 NOT touched.
+// History note: this used to treat the flag as "isSystem" (inverted!), so
+// every code/data entry silently ZEROED its successor entry.  That stayed
+// latent while init_GDT wrote entries in ascending order (each casualty was
+// rewritten by the next call) and only bit when the user code/data GDT order
+// was swapped for SYSRET — the last write wiped the user code descriptor and
+// every ring-3 iretq died with #GP(selector).
+void set_gdt_entry(gdt_entry_t* gdt_table, int entryNo, uint64_t base, uint32_t limit, uint8_t access, uint8_t flags, uint8_t sFlag)
 {
     // Set the first 8-byte entry
     gdt_table[entryNo].base_low = base & 0xFFFF;			//32 bits
@@ -25,7 +39,7 @@ void set_gdt_entry(gdt_entry_t* gdt_table, int entryNo, uint64_t base, uint32_t 
     gdt_table[entryNo].access = access;
 
     // Handle system descriptor setup
-    if (isSystem)
+    if (sFlag == GDT_S_SYSTEM_SEGMENT)
         set_gdt_entry_additional_for_system_descriptors((gdt_entry_additional_t*)&gdt_table[entryNo + 1], base);
 	else
         gdt_table[entryNo].access |= 0x10;

--- a/kernel/src/memory/paging.c
+++ b/kernel/src/memory/paging.c
@@ -146,7 +146,16 @@ void paging_map_page(pt_entry_t *pml4v, uint64_t virtual_address, uint64_t physi
     physical_address &= PAGE_ADDRESS_MASK;
     virtual_address &= PAGE_ADDRESS_MASK;
 
-	uint8_t tableRequiredFlags = (flags & PAGE_WRITE)?PAGE_WRITE:0;
+	// Flags that must be present at EVERY level of the walk, not just the PTE:
+	// on x86-64 an access is only permitted if the needed right exists in the
+	// PML4E, PDPTE, and PDE as well as the leaf.  WRITE was always propagated;
+	// PAGE_USER must be too — a ring-3 access to a page whose leaf says USER
+	// but whose PDE doesn't still faults (#PF error 0x15 on a fetch: present +
+	// user + instruction).  This bit never mattered before the first true
+	// ring-3 task: supervisor accesses ignore U/S, so ring-0 ELF tasks ran
+	// happily on USER-less intermediate tables.  Permissions still ENFORCE at
+	// the leaf — a USER intermediate over a supervisor-only PTE grants nothing.
+	uint8_t tableRequiredFlags = (flags & (PAGE_WRITE | PAGE_USER));
 
 	if ((uintptr_t)pml4v < kHHDMOffset)
 		pml4v = (pt_entry_t *)((uintptr_t)pml4v | kHHDMOffset);

--- a/kernel/src/scheduler.S
+++ b/kernel/src/scheduler.S
@@ -88,7 +88,20 @@ _schedule_ap:
     # We then push RBX below that frame before doing any work.
     # NOTE: Throughout this routine we will use RAX (the apic_id) for the index into each mp_isrSaved array variable
     # and RBX for the data to be stored to each mp_isrSaved array variable
-	sti
+    #
+    # INTERRUPTS STAY OFF until mp_inScheduler is set (below).  The old `sti`
+    # here opened a re-entry window: a HARDWARE scheduler interrupt is shielded
+    # during this prologue by the APIC (no EOI sent yet -> same-priority
+    # delivery held), but the late scheduler_yield() entered via SOFTWARE
+    # `int`, which never sets the APIC in-service bit — so a pending timer
+    # interrupt (very likely pending: syscalls run with IF masked) could nest
+    # into this handler between the old sti and the mp_inScheduler store,
+    # clobbering temp_rsp and the mp_isrSaved arrays with this handler's own
+    # half-saved context; the eventual "resume" then iretq'd into garbage
+    # (first seen as a #GP at a non-canonical RIP on syscall_smoke's first
+    # yield).  scheduler_yield and its software `int` are gone — every entry
+    # is a real LAPIC interrupt now — but the guard-before-sti ordering stays:
+    # it is correct for any entry path, present or future.
     push rbx                            # Save original RBX value
 
     mov rbx, rax                        # Put the original RAX value in RBX
@@ -113,6 +126,10 @@ already_in_scheduler_exit:
 not_in_scheduler_continue:
     # Tag AP as 'in scheduler'
 	mov byte ptr [mp_inScheduler + rax], 1
+
+	# Guard flag is up — a nested scheduler entry now exits via the
+	# already_in_scheduler path, so it is safe to take interrupts again.
+	sti
 
 	# If the BSP is running the scheduler, do the signal check
 	cmp rax, 0
@@ -140,16 +157,36 @@ over_check_signals:
 	mov rbx, [rbx + 8]
 	mov [mp_isrSavedCS + rax * 8], rbx
 
-	# RFLAGS has the SAME constraint as RIP/CS: for a ring0 task with its own
-	# PML4 the interrupt frame sits on that task's own lower-half ring0 stack,
-	# which is NOT mapped in kKernelPML4. So read it from the frame here, BEFORE
-	# the CR3 switch, rather than after (where the dereference would hit the wrong
-	# physical page, or fault). Frame layout: [temp_rsp+0]=RIP, +8=CS, +16=RFLAGS,
-	# +24=RSP, +32=SS. (RSP/SS below don't dereference the frame, so they're fine
-	# after the switch.)
+	# RFLAGS/RSP/SS have the SAME constraint as RIP/CS: for a task with its own
+	# PML4 (ring0 kernel task OR ring3 user task) the interrupt frame sits on a
+	# stack that is NOT mapped in kKernelPML4. So read ALL FIVE frame fields
+	# here, BEFORE the CR3 switch, rather than after (where the dereference
+	# would hit the wrong physical page, or fault). Frame layout:
+	# [temp_rsp+0]=RIP, +8=CS, +16=RFLAGS, +24=RSP, +32=SS — long mode ALWAYS
+	# pushes all five, even ring0->ring0, so this is valid for every entry.
 	mov rbx, [temp_rsp + rax * 8]
 	mov rbx, [rbx + 16]
 	mov [mp_isrSavedRFlags + rax * 8], rbx
+
+	# RSP must come from the frame's +24 field — NOT from temp_rsp arithmetic.
+	# The CPU aligns RSP down to a 16-byte boundary before pushing an interrupt
+	# frame in 64-bit mode, so "frame base + 40" only recovers the ALIGNED
+	# value: any interrupted RSP not on a 16-byte boundary loses its remainder
+	# (up to 15 bytes) and the thread resumes reading byte-shifted qwords off
+	# its own stack.  -O0 C code masked this for years (every leave/ret resyncs
+	# RSP from RBP); the syscall path's hand-written asm finally exposed it as
+	# a #GP at a byte-shifted non-canonical RIP.  The +24 field is the TRUE
+	# pre-alignment RSP, pushed by the CPU itself.
+	mov rbx, [temp_rsp + rax * 8]
+	mov rbx, [rbx + 24]
+	mov [mp_isrSavedRSP + rax * 8], rbx
+
+	# SS from the frame's +32 field, same reasoning (and the frame value is
+	# correct for BOTH rings: ring0 pushes the current kernel SS, ring3 pushes
+	# the user SS).
+	mov rbx, [temp_rsp + rax * 8]
+	mov rbx, [rbx + 32]
+	mov [mp_isrSavedSS + rax * 8], rbx
 
     mov rbx, kKernelPML4
     mov cr3, rbx
@@ -181,54 +218,17 @@ dontSkipRegisters:
     mov [mp_isrSavedES + rax * 8], rbx
     mov ebx, fs
     mov [mp_isrSavedFS + rax * 8], rbx
-    # Figure out if the CS was a kernel process or not, using the value saved before CR3 switch.
-    # Reading via temp_rsp after the CR3 switch would give garbage for tasks with their own PML4.
-    mov rbx, [mp_isrSavedCS + rax * 8]
-    and rbx, 3
-    cmp rbx, 3
-    jne same_priv_lvl_save_stack_and_flags
 
-    # For ring 3 processes, we need to save the SS/ESP/Flags from the stack
-    # NOTE: ring-3 frames land on the kernel interrupt stack (RSP0, HHDM), accessible after CR3 switch
-    # TODO: Verify for ring-3 tasks with their own PML4
-    mov rcx, [temp_rsp + rax * 8]
-	mov rbx, [rcx + 32]
-    mov [mp_isrSavedSS + rax * 8], rbx
-    # Get the RSP value from the interrupt stack frame (ring 3 pushes RIP/CS/RFLAGS/RSP/SS)
-	mov rbx, [rcx + 24]
-	mov [mp_isrSavedRSP + rax * 8], rbx
-    # RFLAGS already saved from the frame before the CR3 switch (see above).
-    jmp over_save_samel_priv_lvl_stack_and_flags
+    # RIP/CS/RFLAGS/RSP/SS were ALL saved from the interrupt frame before the
+    # CR3 switch above — the 5-QWORD frame is identical in shape for ring0 and
+    # ring3 entries (long mode always pushes all five), so no per-ring branch
+    # is needed here anymore.  The old ring0 arm computed RSP as frame+40,
+    # which loses the interrupted RSP's low bits to the CPU's 16-byte frame
+    # alignment; the old ring3 arm dereferenced the frame AFTER the CR3 switch,
+    # which reads the wrong physical page for a user task with its own PML4
+    # (its RSP0 kernel stack is task-local, not HHDM).  Both are now handled
+    # by the single pre-switch frame read.
 
-same_priv_lvl_save_stack_and_flags:
-    # For ring 0 processes, we need to save the SS/ESP/Flags from current values
-    mov rbx, ss
-    mov [mp_isrSavedSS + rax * 8], rbx
-    # IMPORTANT x86-64 detail: in 64-bit long mode an interrupt ALWAYS pushes the
-    # full 5-QWORD frame (SS, RSP, RFLAGS, CS, RIP = 40 bytes), even when there is
-    # NO privilege change (ring 0 -> ring 0).  This differs from 32-bit protected
-    # mode, where a same-privilege interrupt pushes only 3 entries (no SS/ESP).
-    # temp_rsp points at the RIP field (bottom of the frame), so:
-    #   original_RSP = temp_rsp + 40   (the value the thread had before the interrupt)
-    # iretq also pops all 5 entries, so save/restore stays symmetric.
-    #
-    # Do NOT change this to +24: that assumes the 32-bit "3 QWORD" rule and yields
-    # saved_RSP = original_RSP - 16.  On resume the thread runs with RSP 16 bytes
-    # too low; if it was preempted at a function's very first 'push %rbp' (before
-    # the prologue sets up RBP), the callee builds its frame off the wrong RSP and
-    # reads garbage locals — e.g. memcpy reading a bogus length, running away up
-    # the stack, smashing return addresses, and faulting with #UD/#GP.
-	mov rbx, [temp_rsp + rax * 8]
-	add rbx, 40
-    mov [mp_isrSavedRSP + rax * 8], rbx
-    # RFLAGS already saved from the frame BEFORE the CR3 switch (see the pre-switch
-    # save near RIP/CS). Reading it here would dereference the interrupted ring0
-    # stack under kKernelPML4 -- the wrong physical page for an own-PML4 kernel task.
-
-over_save_samel_priv_lvl_stack_and_flags:
-	# CS and RIP already saved from the interrupt frame before the CR3 switch above.
-
-    
 OverSaveRegisters:
     # Keep track of how many times we've entered the scheduler
     inc qword ptr [mp_timesEnteringScheduler + rax*8]
@@ -245,7 +245,9 @@ overSetESP:
 	# Put the apic_id back in RAX
 	pop rax                 			# apic_id is now in EAX
     
-    # Identify whether the new CS is ring 3 for setting the threadIsKernel entry
+    # Identify whether the new CS is ring 3 for setting the threadIsKernel entry.
+    # (Informational/debug only since the ring0/ring3 return paths were unified —
+    # iretq handles both privilege levels from the same 5-qword frame.)
     mov rbx, [mp_isrSavedCS + rax * 8]
     and rbx, 3
     cmp rbx, 3
@@ -292,13 +294,17 @@ kernelProcess:
     mov CR3, rax
 overRestoreCR3:
 
-    # If the new thread to be executed is ring 3, jump to a different return path
     pop rax
-    mov bl, [threadIsKernel + rax * 1]
-    cmp bl,1           
-    jne ring3Return
 
-# Ring 0 return (I expected to not have to do this for a same priv lvl return but I have to anyways)
+# Unified ring0/ring3 return.  iretq consumes the SAME full 5-qword frame
+# (SS:RSP:RFLAGS:CS:RIP) for both cases — for a ring3 CS (RPL 3) it performs
+# the privilege drop and stack switch natively, and unlike the old retfq-based
+# ring3Return path it also restores RFLAGS from the frame, so user tasks start
+# with IF=1 and stay preemptible (retfq left ring 3 running with interrupts
+# off — whatever popf loaded stayed loaded, and we had cleared IF).
+# (I expected to not have to push SS:RSP for a same-priv-level return but I
+# have to anyways — long mode always pushes/pops all 5, so save/restore stays
+# symmetric.)
     mov rbx, [mp_isrSavedSS + rax * 8]
     push rbx
 	mov rbx, [mp_isrSavedRSP + rax * 8]
@@ -373,40 +379,6 @@ scheduler_continue_2:
 	mov byte ptr [mp_inScheduler + rax], 0
     mov rax, [mp_isrSavedRAX + rax * 8]
     iretq
-
-
-
-ring3Return:
-    # NOTE: EAX still holds apic_id
-    mov rbx, [mp_isrSavedRIP + rax * 8]
-    mov [rsp], rbx
-    mov rbx, [mp_isrSavedCS + rax * 8]
-    mov [rsp + 8], rbx
-    mov rbx, [mp_isrSavedRSP + rax * 8]
-    mov [rsp + 16], rbx
-    mov ebx, [mp_isrSavedSS + rax * 8]
-    mov [rsp + 24], rbx
-    mov bl,[mp_SchedulerTaskSwitched + rax]			# mp_SchedulerTaskSwitched is a byte array, 1 byte per core
-    cmp bl,0
-    jnz newTaskLoaded
-    jmp doTheJump
-
-newTaskLoaded:
-    # Stack is already where it was when we started the ISR
-    # reset the task switched indicator
-    mov ebx,0
-    mov [mp_SchedulerTaskSwitched + rax], bl
-
-doTheJump:
-    mov rbx, [mp_isrSavedRFlags + rax * 8]
-    and rbx, 0xFFFFFFFFFFFFFDFF                         # Clear the IF flag
-    push rbx
-    popf
-	mov rbx, [mp_isrSavedRBX + rax * 8]
-	mov byte ptr [mp_inScheduler + rax], 0
-    mov rax, [mp_isrSavedRAX + rax * 8]
-    call _write_eoi
-    retfq 0
 
 .section .data
 .align 8

--- a/kernel/src/scheduler.c
+++ b/kernel/src/scheduler.c
@@ -64,11 +64,12 @@ extern bool kSMPInitDone;
 
 const char* THREAD_STATE_NAMES[] = {"None","Running","Runnable","Stopped","Uninterruptable Sleep","Interruptable Sleep","Exited","Zombie"};
 
-// Trap into the scheduler ISR directly so voluntary yields don't depend on a LAPIC IPI.
-static inline void scheduler_invoke_vector(void)
-{
-	asm volatile("int %0" :: "i"(IPI_MANUAL_SCHEDULE_VECTOR) : "memory");
-}
+// NOTE: there was a scheduler_invoke_vector() here that entered the scheduler
+// with a direct software `int`.  Removed with scheduler_yield(): a software
+// int never sets the APIC in-service bit, so such entries dodge the
+// EOI-based nesting protection that every hardware/IPI entry gets.  All
+// scheduler entries now go through a real LAPIC interrupt (timer or
+// send_ipi in scheduler_trigger).
 
 static bool scheduler_thread_can_run_on_core(thread_t *thread, core_local_storage_t *cls)
 {
@@ -698,22 +699,14 @@ void scheduler_trigger(core_local_storage_t *cls)
     cls = get_core_local_storage();
 }
 
-/// @brief Yield control of the CPU
-/// @param cls Optional - can be NULL if not valid in the calling context
-/// @details Yields control of the CPU if there is another thread that is ready to run.  If not, does a sti\nhlt\n to wait for the next timer tick (BSP) or scheduling IPI
-void scheduler_yield(core_local_storage_t *cls)
-{
-	 if (!cls)
-	 	cls = get_core_local_storage();
-
-	thread_t* thread=scheduler_find_thread_to_run(cls, true);
-
-	//If another thread is ready to run then trigger the scheduler, otherwise just hlt until the next scheduling IPI
-	if (thread != NO_THREAD && thread->threadID != cls->threadID)
-		scheduler_invoke_vector();
-	else
-		__asm__("sti\nhlt\n");
-}
+// scheduler_yield() used to live here.  It was retired in favor of
+// scheduler_trigger() (above) once syscalls started yielding: it entered the
+// scheduler via a direct software `int`, which never sets the APIC in-service
+// bit — so unlike every hardware entry it had NO nesting protection (a
+// pending timer could re-enter _schedule_ap mid-prologue), and its
+// peek-the-queue-then-fire logic raced the world changing in between.
+// scheduler_trigger's genuine self-IPI gives every scheduler entry — timer or
+// manual — identical interrupt semantics.
 
 void scheduler_run_new_thread()
 {

--- a/kernel/src/smp_core.c
+++ b/kernel/src/smp_core.c
@@ -303,13 +303,35 @@ void ap_initialization_handler() {
 
     // NOTE: Stack was already initialized in ap_wakeup_entry
 
-	//STAR MSR
-	//Format: 63..48 | 47..32 | 31..16 | 15..0
-	//--------|--------|--------|-------
-	//Reserved| Kernel CS Segment Selector | User CS Segment Selector | Reserved (zeros)
-	uint64_t starValue = ((uint64_t)GDT_KERNEL_CODE_ENTRY << 3) << 32 | ((GDT_USER_CODE_ENTRY << 3) | 3) << 16;
+	//STAR MSR — segment selectors for the SYSCALL/SYSRET fast path.
+	//Format: 63..48                 | 47..32                  | 31..0
+	//--------|------------------------|-------------------------|------
+	//        | SYSRET base selector   | SYSCALL base selector   | legacy 32-bit SYSCALL EIP (unused in long mode)
+	//
+	//SYSCALL loads CS = STAR[47:32] and SS = STAR[47:32]+8, so the base is simply
+	//the kernel code selector (kernel data sits right after it in the GDT).
+	//
+	//SYSRETQ loads CS = STAR[63:48]+16 and SS = STAR[63:48]+8, so the base must be
+	//8 BELOW the user data selector, with user code 8 above user data (the GDT is
+	//laid out to satisfy this — see gdt.h).  RPL 3 is baked into the base so the
+	//loaded selectors carry ring 3.  Both layout preconditions are asserted below
+	//so a GDT reshuffle fails the build instead of #GP'ing on the first sysret.
+	_Static_assert(GDT_KERNEL_DATA_ENTRY == GDT_KERNEL_CODE_ENTRY + 1,
+	               "SYSCALL requires kernel data GDT entry immediately after kernel code");
+	_Static_assert(GDT_USER_CODE_ENTRY == GDT_USER_DATA_ENTRY + 1,
+	               "SYSRETQ requires user code GDT entry immediately after user data");
 
-    wrmsr64(STAR_MSR,starValue);                      //Set sysenter CS(88) and SS(33), and return CS(93) & SS(3b)
+	uint64_t syscallBase = (uint64_t)GDT_KERNEL_CODE_ENTRY << 3;
+	uint64_t sysretBase  = ((uint64_t)(GDT_USER_DATA_ENTRY - 1) << 3) | 3;
+	uint64_t starValue   = (sysretBase << 48) | (syscallBase << 32);
+
+    wrmsr64(STAR_MSR,starValue);   //SYSCALL: CS=0x28/SS=0x30; SYSRETQ: CS=0x43/SS=0x3B (RPL 3)
+
+	//EFER.SCE — actually ENABLE the SYSCALL/SYSRET instructions.  The boot
+	//environment leaves EFER with LME/LMA/NXE only; without SCE, `syscall`
+	//raises #UD no matter how carefully STAR/LSTAR/SFMASK were programmed.
+	//Per-core like the rest of this block (EFER is a per-core MSR).
+	wrmsr64(EFER_MSR, rdmsr64(EFER_MSR) | EFER_SCE);
 
 	//LSTAR MSR
 	//Format: 63..0 = Entry point to the kernel's system call method

--- a/kernel/src/syscall.S
+++ b/kernel/src/syscall.S
@@ -4,21 +4,45 @@
 .section .text
 .intel_syntax noprefix
 
-.extern _syscall
+.extern _syscall_dispatch
+
+# ── os64 SYSCALL entry ────────────────────────────────────────────────────────
+#
+# Hardware state on arrival (SYSCALL from ring 3):
+#   RCX = user RIP (the instruction after `syscall`)     — set by the CPU
+#   R11 = user RFLAGS                                    — set by the CPU
+#   RSP = STILL THE USER STACK (SYSCALL switches CS/SS but NOT the stack)
+#   CR3 = still the user address space (kernel is mapped in every user PML4)
+#   IF  = 0 (masked by SFMASK), so nothing can preempt us until we choose
+#
+# os64 syscall register convention (see syscall_numbers.h for the numbers):
+#   RAX = syscall number
+#   RDI, RSI, RDX, R10, R8, R9 = args 0-5   (R10 stands in for RCX, which the
+#                                            CPU burned for the return RIP)
+#   RAX = result
+#   CLOBBERED for the caller: RCX, R11 (by the hardware), plus all C
+#   caller-saved registers (RDI, RSI, RDX, R8-R10) — the same set a plain C
+#   function call would clobber, so a C syscall stub needs no special saving.
+#   Callee-saved registers (RBX, RBP, R12-R15) are preserved.
+#
+# Design rule: NEVER touch the user stack here.  A ring-3 program that points
+# RSP at garbage and executes `syscall` must not be able to fault the kernel
+# (a #PF here, before we have a good stack, would double-fault).  So the user
+# RSP is stashed GS-relative in core-local storage — safe because IF is masked,
+# so nothing runs on this core between the store and the reload below.
 
 .globl syscall_Enter
 .type syscall_Enter, @function
 syscall_Enter:
-    # Save user return state on the user stack so we can reclaim the registers
-    push r11                         # user RFLAGS
-    push rcx                         # user RIP
-    lea r11, [rsp + 16]              # r11 now holds original user RSP
+    # Stash the user RSP in CLS and switch to this thread's kernel stack.
+    # kernel_rsp0 is kept in sync with the running thread by tss_set_rsp0()
+    # on every context switch, and is 16-byte aligned (stack top - 48).
+    mov gs:[CLS_SYSCALL_USER_RSP_OFFSET], rsp
+    mov rsp, gs:[CLS_KERNEL_RSP0_OFFSET]
 
-    # Switch to the current kernel stack (stored in the per-core TSS)
-    mov rcx, qword ptr [gs:0]
-    mov rsp, qword ptr [rcx + CLS_KERNEL_RSP0_OFFSET]
-
-    # Preserve callee-saved registers used by the kernel dispatcher
+    # Preserve the callee-saved registers (they hold live user values; the C
+    # dispatcher is free to use them and will restore its own uses, but WE use
+    # r12 as scratch below, and the convention above promises to preserve them).
     push rbx
     push rbp
     push r12
@@ -26,26 +50,38 @@ syscall_Enter:
     push r14
     push r15
 
-    # Reserve space for the saved user context (rflags, rip, rsp) and padding for alignment
-    sub rsp, 32
+    # Frame for the user return context: [0]=RFLAGS, [8]=RIP, [16]=user RSP,
+    # [24..39]=padding.  40 (not 32) so that after the `push r9` in the arg
+    # marshal below, the C dispatcher is entered with RSP%16==8 per the ABI.
+    sub rsp, 40
+    mov [rsp], r11                              # user RFLAGS
+    mov [rsp + 8], rcx                          # user RIP
+    mov r12, gs:[CLS_SYSCALL_USER_RSP_OFFSET]
+    mov [rsp + 16], r12                         # user RSP
 
-    # Capture the user-space context for the eventual sysret
-    mov r12, qword ptr [r11 - 8]     # user RFLAGS that were pushed earlier
-    mov r13, qword ptr [r11 - 16]    # user RIP
-    mov [rsp], r12
-    mov [rsp + 8], r13
-    mov [rsp + 16], r11              # original user RSP
+    # Marshal the syscall registers into the SysV C argument slots for
+    #   uint64_t _syscall_dispatch(nr, a0, a1, a2, a3, a4, a5)
+    # i.e. RDI,RSI,RDX,RCX,R8,R9 + one stack slot.  Order matters: each move
+    # writes a register only after its original value has been consumed.
+    push r9                                     # a5 -> 7th arg (stack)
+    mov r9, r8                                  # a4
+    mov r8, r10                                 # a3
+    mov rcx, rdx                                # a2
+    mov rdx, rsi                                # a1
+    mov rsi, rdi                                # a0
+    mov rdi, rax                                # syscall number
+    call _syscall_dispatch
+    add rsp, 8                                  # drop the stacked a5
 
-    # Dispatch the syscall; arguments remain in their ABI registers
-    call _syscall
+    # Result stays in RAX all the way back to the user.
+    # Rebuild the SYSRET context from the saved frame.  RSI is used to carry
+    # the user RSP across the callee-saved pops (it's caller-saved — already
+    # documented as clobbered).
+    mov r11, [rsp]                              # user RFLAGS (SYSRET reloads from R11)
+    mov rcx, [rsp + 8]                          # user RIP    (SYSRET reloads from RCX)
+    mov rsi, [rsp + 16]                         # user RSP
+    add rsp, 40
 
-    # Prepare the return context
-    mov rdx, [rsp]                   # user RFLAGS
-    mov rcx, [rsp + 8]               # user RIP
-    mov rsi, [rsp + 16]              # user RSP
-    add rsp, 32
-
-    # Restore callee-saved registers
     pop r15
     pop r14
     pop r13
@@ -53,8 +89,9 @@ syscall_Enter:
     pop rbp
     pop rbx
 
-    # Restore the user return state and drop back to ring3
-    mov r11, rdx
+    # Back to the user stack and drop to ring 3.  SYSRETQ loads CS/SS from
+    # STAR[63:48] (see smp_core.c) and RFLAGS from R11 — the user's IF comes
+    # back on here (user RFLAGS always has IF set).
     mov rsp, rsi
     sysretq
 

--- a/kernel/src/syscall.c
+++ b/kernel/src/syscall.c
@@ -1,12 +1,15 @@
 #include "syscall.h"
+#include "syscall_numbers.h"
 
 #include <stddef.h>
 #include <stdint.h>
 
 #include "BasicRenderer.h"
+#include "panic.h"
 #include "printd.h"
 #include "scheduler.h"
 #include "smp_core.h"
+#include "task.h"
 #include "memory/memcpy.h"
 #include "memory/paging.h"
 #include "log.h"
@@ -20,31 +23,42 @@ static bool g_saved_cr3_valid[MAX_CPUS];
 static inline uint32_t get_current_cpu_index(void);
 static bool prepare_syscall_args(const syscall_entry_t *entry, const uint64_t incoming[6], uint64_t prepared[6]);
 static bool copy_user_string(const char *user_str, char *buffer, size_t buffer_len);
+static bool copy_user_buffer(const void *user_src, void *kernel_dst, size_t length);
 
 static uint64_t syscall_yield(uint64_t arg0, uint64_t arg1, uint64_t arg2,
     uint64_t arg3, uint64_t arg4, uint64_t arg5);
 static uint64_t syscall_debug_log(uint64_t arg0, uint64_t arg1, uint64_t arg2,
     uint64_t arg3, uint64_t arg4, uint64_t arg5);
+static uint64_t syscall_exit(uint64_t arg0, uint64_t arg1, uint64_t arg2,
+    uint64_t arg3, uint64_t arg4, uint64_t arg5);
+static uint64_t syscall_write(uint64_t arg0, uint64_t arg1, uint64_t arg2,
+    uint64_t arg3, uint64_t arg4, uint64_t arg5);
 
+// NOTE: syscall.S marshals the syscall registers straight into
+// _syscall_dispatch()'s C arguments — there is deliberately no C-level entry
+// shim here (the old register-pinned-locals version relied on behavior GCC
+// only guarantees for inline-asm operands).
+// Last column is user_ptr_arg_mask: bit i = "arg i is a user pointer, range-
+// check it at the boundary".  Non-pointer args (handles, lengths, exit codes)
+// and unused arg registers (ring-3 garbage!) must NOT be checked.
+//
+// needs_cr3_switch is FALSE for every current entry, on purpose.  Handlers run
+// on the calling task's CR3, which maps BOTH the user's buffers (lower half)
+// AND the whole kernel (upper half is shared into every task PML4) — there is
+// nothing a syscall needs that the user CR3 can't see.  Switching to
+// kKernelPML4 mid-syscall is actively fatal: the thread's syscall kernel stack
+// is a task-local VA that kKernelPML4 does NOT map, so the first C statement
+// after the switch touches an unmapped stack -> #PF -> the #PF handler pushes
+// onto the same unmapped stack -> double -> TRIPLE FAULT (write() proved this
+// the very first time the flag was ever exercised).  If a future syscall
+// genuinely needs kernel context, it must switch STACK and CR3 together — see
+// call_in_kernel_context in task_exit_asm.S for the proven pattern.
 syscall_entry_t syscall_table[MAX_SYSCALLS] = {
-	SYSCALL_DEFINE(0, "yield", syscall_yield, false, false),
-	SYSCALL_DEFINE(1, "debug_log", syscall_debug_log, true, true),
+	SYSCALL_DEFINE(SYSCALL_YIELD,     "yield",     syscall_yield,     false, 0x00),
+	SYSCALL_DEFINE(SYSCALL_DEBUG_LOG, "debug_log", syscall_debug_log, false, 0x01),  // arg0 = message
+	SYSCALL_DEFINE(SYSCALL_EXIT,      "exit",      syscall_exit,      false, 0x00),
+	SYSCALL_DEFINE(SYSCALL_WRITE,     "write",     syscall_write,     false, 0x02),  // arg1 = buffer
 };
-
-uint64_t _syscall(void)
-{
-	register uint64_t syscall_number __asm__("rax");
-	register uint64_t arg0 __asm__("rdi");
-	register uint64_t arg1 __asm__("rsi");
-	register uint64_t arg2 __asm__("rdx");
-	register uint64_t arg3 __asm__("r10");
-	register uint64_t arg4 __asm__("r8");
-	register uint64_t arg5 __asm__("r9");
-
-	return _syscall_dispatch(syscall_number,
-		arg0, arg1, arg2,
-		arg3, arg4, arg5);
-}
 
 uint64_t _syscall_dispatch(
 	uint64_t syscall_number,
@@ -54,6 +68,10 @@ uint64_t _syscall_dispatch(
 	const uint64_t raw_args[6] = { arg0, arg1, arg2, arg3, arg4, arg5 };
 	uint64_t prepared_args[6] = {0};
 	bool switched_cr3 = false;
+	uint64_t entry_cr3 = 0;
+
+	// Remember the address space we arrived on for the exit tripwire below.
+	asm volatile("mov %0, cr3" : "=r"(entry_cr3));
 
 	if (syscall_number >= MAX_SYSCALLS)
 	{
@@ -92,6 +110,19 @@ uint64_t _syscall_dispatch(
 	if (switched_cr3)
 	{
 		restore_user_cr3();
+	}
+
+	// Boundary tripwire (a keeper from the 32-bit OS): a syscall must leave on
+	// the same address space it arrived on.  Escaping to ring 3 with the kernel
+	// CR3 still loaded "works" (kernel maps are a superset) right up until it
+	// corrupts something unrelated, so catch it here where the cause is obvious.
+	// (Threads that legitimately ARRIVED on the kernel CR3 are exempt.)
+	uint64_t exit_cr3 = 0;
+	asm volatile("mov %0, cr3" : "=r"(exit_cr3));
+	if (exit_cr3 != entry_cr3)
+	{
+		panic("_syscall_dispatch: syscall %lu (%s) entered on CR3 %#lx but is leaving on %#lx\n",
+		      syscall_number, entry->name ? entry->name : "(unnamed)", entry_cr3, exit_cr3);
 	}
 
 	return result;
@@ -138,8 +169,10 @@ bool validate_and_copy_user_data(const void* user_ptr, size_t length, void* kern
 
 	uintptr_t user_address = (uintptr_t)user_ptr;
 
-	// Reject addresses that clearly point into kernel-mapped memory
-	if (user_address >= kHHDMOffset)
+	// Reject ranges that start in — or run into — kernel-mapped memory.  The
+	// subtraction form also catches user_address+length overflowing to wrap
+	// back below kHHDMOffset.
+	if (user_address >= kHHDMOffset || length > kHHDMOffset - user_address)
 	{
 		return false;
 	}
@@ -180,17 +213,22 @@ static inline uint32_t get_current_cpu_index(void)
 	return (uint32_t)apic_id;
 }
 
+// Boundary validation of user-pointer arguments, driven by the entry's
+// user_ptr_arg_mask.  Only args the table declares as pointers are checked —
+// see the mask's comment in syscall.h for why checking all six is a bug, not
+// extra safety.  NULL is allowed through here so handlers can give it a
+// per-call meaning (the copy helpers reject NULL where it matters).
 static bool prepare_syscall_args(const syscall_entry_t *entry, const uint64_t incoming[6], uint64_t prepared[6])
 {
 	memcpy(prepared, incoming, sizeof(uint64_t) * 6);
 
-	if (!entry->needs_user_copy)
-	{
-		return true;
-	}
-
 	for (size_t i = 0; i < 6; ++i)
 	{
+		if (!(entry->user_ptr_arg_mask & (1u << i)))
+		{
+			continue;
+		}
+
 		if (prepared[i] == 0)
 		{
 			continue;
@@ -205,6 +243,49 @@ static bool prepare_syscall_args(const syscall_entry_t *entry, const uint64_t in
 	return true;
 }
 
+// ── User-copy CR3 window ─────────────────────────────────────────────────────
+// The dispatcher may already have moved this core to the kernel CR3 (entries
+// with needs_cr3_switch), but user pointers only resolve under the USER CR3.
+// The copy helpers below therefore run inside a "window": open() drops back to
+// the user CR3 the dispatcher saved for this core (when there is one), and
+// close() restores whatever was loaded before.  Interrupts are masked for the
+// whole syscall (SFMASK clears IF), so the window can't be preempted while the
+// "wrong" CR3 is live.
+static uint64_t user_cr3_window_open(bool *switched)
+{
+        uint64_t original_cr3 = 0;
+        asm volatile("mov %0, cr3" : "=r"(original_cr3));
+
+        *switched = false;
+        if (original_cr3 == (uint64_t)kKernelPML4)
+        {
+                uint32_t cpu_index = get_current_cpu_index();
+                if (g_saved_cr3_valid[cpu_index])
+                {
+                        uint64_t user_cr3 = g_saved_cr3[cpu_index];
+                        if (user_cr3 && user_cr3 != (uint64_t)kKernelPML4)
+                        {
+                                asm volatile("mov cr3, %0" :: "r"(user_cr3) : "memory");
+                                *switched = true;
+                        }
+                }
+        }
+
+        return original_cr3;
+}
+
+static void user_cr3_window_close(uint64_t original_cr3, bool switched)
+{
+        if (switched)
+        {
+                asm volatile("mov cr3, %0" :: "r"(original_cr3) : "memory");
+        }
+}
+
+// Copy a NUL-terminated string from user space into a kernel buffer, walking
+// byte-by-byte so an unterminated user string can't run past buffer_len.
+// Returns false if the user range is invalid or no NUL appears within the
+// buffer (the buffer is still NUL-terminated for safe logging either way).
 static bool copy_user_string(const char *user_str, char *buffer, size_t buffer_len)
 {
         if (!user_str || !buffer || buffer_len == 0)
@@ -212,25 +293,8 @@ static bool copy_user_string(const char *user_str, char *buffer, size_t buffer_l
                 return false;
         }
 
-        uint64_t original_cr3 = 0;
-        asm volatile("mov %0, cr3" : "=r"(original_cr3));
-
-        const uint64_t kernel_cr3 = (uint64_t)kKernelPML4;
-        bool temporarily_switched_to_user_cr3 = false;
-
-        if (original_cr3 == kernel_cr3)
-        {
-                uint32_t cpu_index = get_current_cpu_index();
-                if (cpu_index < MAX_CPUS && g_saved_cr3_valid[cpu_index])
-                {
-                        uint64_t user_cr3 = g_saved_cr3[cpu_index];
-                        if (user_cr3 && user_cr3 != kernel_cr3)
-                        {
-                                asm volatile("mov cr3, %0" :: "r"(user_cr3) : "memory");
-                                temporarily_switched_to_user_cr3 = true;
-                        }
-                }
-        }
+        bool switched = false;
+        uint64_t original_cr3 = user_cr3_window_open(&switched);
 
         bool success = false;
         size_t written = 0;
@@ -253,11 +317,26 @@ static bool copy_user_string(const char *user_str, char *buffer, size_t buffer_l
         buffer[buffer_len - 1] = '\0';
 
 out:
-        if (temporarily_switched_to_user_cr3)
+        user_cr3_window_close(original_cr3, switched);
+        return success;
+}
+
+// Copy exactly `length` bytes from user space into a kernel buffer.  The
+// length-based sibling of copy_user_string, for payloads that aren't strings
+// (write() buffers may legally contain NUL bytes).
+static bool copy_user_buffer(const void *user_src, void *kernel_dst, size_t length)
+{
+        if (!user_src || !kernel_dst || length == 0)
         {
-                asm volatile("mov cr3, %0" :: "r"(original_cr3) : "memory");
+                return false;
         }
 
+        bool switched = false;
+        uint64_t original_cr3 = user_cr3_window_open(&switched);
+
+        bool success = validate_and_copy_user_data(user_src, length, kernel_dst);
+
+        user_cr3_window_close(original_cr3, switched);
         return success;
 }
 
@@ -271,7 +350,13 @@ static uint64_t syscall_yield(uint64_t arg0, uint64_t arg1, uint64_t arg2,
 	(void)arg4;
 	(void)arg5;
 
-	scheduler_yield(NULL);
+	// scheduler_trigger: genuine APIC self-IPI into the scheduler, same entry
+	// semantics as the timer path (in-service bit, EOI discipline).  Returns
+	// as soon as the scheduler decides — immediately if nothing else is
+	// runnable, after a context-switch round trip if something was.
+	// (Replaced scheduler_yield, whose direct software `int` bypassed APIC
+	// nesting protection and whose empty-queue path slept a full tick.)
+	scheduler_trigger(NULL);
 	return 0;
 }
 
@@ -294,4 +379,83 @@ static uint64_t syscall_debug_log(uint64_t arg0, uint64_t arg1, uint64_t arg2,
 
 	printf("[user] %s\n", kernel_buffer);
 	return 0;
+}
+
+// exit(code) — terminate the calling task.  arg0 becomes the task's retVal
+// (harvested by task_wait / the test harness).  Everything after the retVal
+// store is task_exit()'s problem: it switches to the per-core kernel interrupt
+// stack and kKernelPML4 itself, marks task+thread exited, and yields away for
+// good — which is why this entry runs with needs_cr3_switch=false (the
+// dispatcher's save/restore bookkeeping would never get to run anyway).
+static uint64_t syscall_exit(uint64_t arg0, uint64_t arg1, uint64_t arg2,
+    uint64_t arg3, uint64_t arg4, uint64_t arg5)
+{
+	(void)arg1;
+	(void)arg2;
+	(void)arg3;
+	(void)arg4;
+	(void)arg5;
+
+	core_local_storage_t *cls = get_core_local_storage();
+	task_t *task = cls ? cls->task : NULL;
+	if (task)
+	{
+		task->retVal = arg0;
+	}
+
+	task_exit();
+	__builtin_unreachable();
+}
+
+// write(handle, buffer, length) — write bytes to an output handle.
+// Until a per-task handle table exists, only the two console handles are
+// valid, and both reach the screen.  Runs entirely on the calling task's CR3
+// (user buffer in the lower half, console/renderer in the shared upper half —
+// see the table comment).  The user buffer is ferried through a bounded
+// kernel chunk so arbitrary user lengths never map to unbounded kernel stack
+// use.  Returns the byte count written, or a SYSCALL_RESULT_* error sentinel.
+#define WRITE_CHUNK_SIZE 512
+static uint64_t syscall_write(uint64_t arg0, uint64_t arg1, uint64_t arg2,
+    uint64_t arg3, uint64_t arg4, uint64_t arg5)
+{
+	(void)arg3;
+	(void)arg4;
+	(void)arg5;
+
+	uint64_t handle = arg0;
+	const char *user_buffer = (const char*)arg1;
+	size_t length = (size_t)arg2;
+
+	if (handle != SYSCALL_HANDLE_CONSOLE_OUT && handle != SYSCALL_HANDLE_CONSOLE_ERR)
+	{
+		return SYSCALL_RESULT_INVALID;
+	}
+
+	if (length == 0)
+	{
+		return 0;
+	}
+
+	char chunk[WRITE_CHUNK_SIZE];
+	size_t copied = 0;
+	while (copied < length)
+	{
+		size_t this_chunk = length - copied;
+		if (this_chunk > sizeof(chunk))
+		{
+			this_chunk = sizeof(chunk);
+		}
+
+		if (!copy_user_buffer(user_buffer + copied, chunk, this_chunk))
+		{
+			// Report progress if some bytes already made it to the console;
+			// only fail outright when nothing was written.
+			return copied ? copied : SYSCALL_RESULT_BAD_USER_DATA;
+		}
+
+		print_n(chunk, this_chunk);
+		copied += this_chunk;
+	}
+
+	return copied;
 }

--- a/kernel/src/task.c
+++ b/kernel/src/task.c
@@ -260,7 +260,11 @@ static void __attribute__((noinline)) task_exit_finish(void)
 		task_enqueue_dead_child(task);
 	}
 
-	scheduler_yield(cls);
+	// Enter the scheduler via its normal APIC-IPI path; it sees the exited
+	// flags set above and moves this thread to the zombie queue.  A dead
+	// thread is never rescheduled, so trigger's wait-loop (and the belt-and-
+	// suspenders hlt loop below) should never actually run to completion.
+	scheduler_trigger(cls);
 
 	while (1==1)
 	{
@@ -327,7 +331,7 @@ task_t* task_wait(task_t* parentTask, uint64_t* exitCode)
 
 		parent->waitingForChild = true;
 		scheduler_change_thread_queue(parent->threads, THREAD_STATE_ISLEEP);
-		scheduler_yield(cls);
+		scheduler_trigger(cls);
 		parent->waitingForChild = false;
 	}
 }
@@ -507,9 +511,78 @@ static void elf_resolve_dynamic_dependencies(task_t *task, const char *path)
 	task->elf = main_so->image;
 	// ET_DYN: e_entry is load_bias-relative, same as every other address in
 	// the image (unlike ET_EXEC, where it would already be absolute).
+	task->loadBias = main_so->load_bias;
 	task->entryPoint = main_so->load_bias + main_so->image->ehdr.e_entry;
 	if (task->threads != NULL) {
 		task->threads->regs.RIP = task->entryPoint;
+	}
+}
+
+// GDB symbol-autoload notch.  utility/os64_symbols.gdb plants a SILENT
+// breakpoint on debug_task_loaded(), reads the two globals below, runs
+// add-symbol-file for kernel/bin/<basename> at the right offset, and resumes
+// without stopping — so every program's debug info appears in GDB the moment
+// the kernel loads it, with all binaries free to share the same link address.
+// Replaces both manual add-symbol-file and the old-OS trick of giving every
+// executable a unique link address.
+//
+// The info travels through GLOBALS (kernel .bss — mapped identically in every
+// address space, trivially readable by the gdbstub) rather than function
+// arguments: the first version passed the kmalloc'd path pointer as an arg
+// and GDB's frame-argument read failed with "Cannot access memory" — frame
+// timing, CR3, and heap-mapping subtleties all conspire against argument
+// parsing, and none of them apply to a fixed-address kernel array.
+// noinline + the asm sliver keep any -O level from eliding the call or the
+// symbol.  Runs (and costs a string copy) whether or not a debugger is
+// attached.
+char kDebugTaskLoadedPath[TASK_MAX_PATH_LEN];
+uint64_t kDebugTaskLoadedBias;
+void __attribute__((noinline)) debug_task_loaded(void)
+{
+	__asm__ volatile("" :: "r"(kDebugTaskLoadedPath), "r"(&kDebugTaskLoadedBias) : "memory");
+}
+
+// Wire up the ring-3 EXIT path for a user task.  Counterpart of the ring0
+// branch in createThread() (which seeds task_exit_with_retval directly —
+// impossible for ring 3, where returning into kernel text faults).
+//
+// Two steps, both prescribed by the 32-bit OS's proven design (processExit):
+//   1. Copy the position-independent trampoline template (task_exit_asm.S)
+//      into a fresh page and map it into the task at TASK_EXIT_TRAMPOLINE_VIRT,
+//      user-visible but READ-ONLY (PAGE_USER without PAGE_WRITE, executable) —
+//      the program can run its exit path but not scribble on it.
+//   2. Seed the trampoline's VA as the initial return address at [regs.RSP]
+//      (createThread left that qword slot for us).  A _start that plainly
+//      `ret`s pops it and lands in the trampoline at CPL 3, which converts
+//      RAX into an exit syscall — same retVal contract as ring0 tasks.
+//
+// The seed is written through the HHDM alias of the stack's physical page
+// (same idiom as the ring0 seeding in createThread) because the user stack VA
+// is only mapped in the task's own PML4, not the kernel's.
+extern const char user_exit_trampoline_template[];
+extern const char user_exit_trampoline_template_end[];
+static void task_setup_ring3_exit_path(task_t *task)
+{
+	if (task->threads == NULL)
+		return;
+
+	size_t template_bytes = (size_t)(user_exit_trampoline_template_end - user_exit_trampoline_template);
+
+	// kmalloc_aligned hands back a zeroed, page-aligned HHDM address; the byte
+	// copy is tiny (a handful of instructions) so one page is plenty.
+	void *trampoline_page = kmalloc_aligned(PAGE_SIZE);
+	memcpy(trampoline_page, user_exit_trampoline_template, template_bytes);
+
+	uintptr_t trampoline_phys = (uintptr_t)trampoline_page - kHHDMOffset;
+	paging_map_pages(task->pml4v, TASK_EXIT_TRAMPOLINE_VIRT, trampoline_phys, 1,
+	                 PAGE_PRESENT | PAGE_USER);
+
+	uintptr_t phys_rsp = paging_walk_paging_table((pt_entry_t*)task->pml4v, task->threads->regs.RSP);
+	if (phys_rsp && phys_rsp != 0xbadbadba) {
+		*(uintptr_t *)(phys_rsp | kHHDMOffset) = (uintptr_t)TASK_EXIT_TRAMPOLINE_VIRT;
+	} else {
+		panic("task_setup_ring3_exit_path: user stack VA 0x%016lx not mapped in task PML4 for %s\n",
+		      task->threads->regs.RSP, task->exename);
 	}
 }
 
@@ -689,6 +762,21 @@ task_t* task_create(char* path, int argc, char** argv, task_t* parentTaskPtr, bo
 	// Must run AFTER the argument/env setup above.
 	if (loadedElfProgram) {
 		task_setup_entry(newTask);
+
+		// Ring-3 tasks also get their exit path wired here (ring-0 ELF tasks
+		// were already seeded with task_exit_with_retval in createThread —
+		// mapping the trampoline for them would overwrite that seed).
+		if (!isKernelTask) {
+			task_setup_ring3_exit_path(newTask);
+		}
+
+		// Tell an attached GDB (if any) which program image just landed and
+		// where, so it can auto-load the matching symbol file.  Stage the
+		// info in the debug globals first — see debug_task_loaded's comment.
+		strncpy(kDebugTaskLoadedPath, newTask->path, TASK_MAX_PATH_LEN);
+		kDebugTaskLoadedPath[TASK_MAX_PATH_LEN - 1] = '\0';
+		kDebugTaskLoadedBias = newTask->loadBias;
+		debug_task_loaded();
 	}
 
 	return newTask;

--- a/kernel/src/task_exit_asm.S
+++ b/kernel/src/task_exit_asm.S
@@ -1,4 +1,5 @@
 #include "asm-offsets.h"
+#include "syscall_numbers.h"
 
 .code64
 .intel_syntax noprefix
@@ -69,3 +70,31 @@ call_in_kernel_context:
     pop  r13
     pop  r12
     ret
+
+// ── Ring-3 exit trampoline TEMPLATE ──────────────────────────────────────────
+//
+// These bytes are never executed here in the kernel image.  task_create()
+// copies them into a user-mapped, read-only+executable page at
+// TASK_EXIT_TRAMPOLINE_VIRT, and seeds that address as the initial return
+// address on every ring-3 thread's user stack.  A user _start that plainly
+// `ret`s therefore lands HERE at CPL 3 (an ordinary ring3→ring3 return — the
+// ring-0 task_exit_with_retval seeding trick can't work for user threads
+// because returning from CPL 3 into kernel text faults), and we convert the
+// C return value into a proper exit syscall:
+//   RAX (SysV return value) → RDI (exit code arg) → SYSCALL_EXIT.
+//
+// Must stay position-independent: RIP-relative jump only, no absolute
+// references (the copy runs at a completely different VA than it was
+// assembled at).  Kept in .rodata — it is DATA to the kernel, and mapping the
+// user page without PAGE_WRITE means the program can't scribble on its own
+// exit path.
+.section .rodata
+.globl user_exit_trampoline_template
+.globl user_exit_trampoline_template_end
+user_exit_trampoline_template:
+    mov  rdi, rax                   // exit code = _start's return value
+    mov  eax, SYSCALL_EXIT
+    syscall
+1:  jmp  1b                         // exit never returns; spin if it somehow does
+user_exit_trampoline_template_end:
+.section .text

--- a/kernel/src/thread.c
+++ b/kernel/src/thread.c
@@ -192,37 +192,29 @@ thread_t* createThread(void* ownerTask, bool kernelThread)
 	}
 	else
 	{
-		// ─── RING3 (user) THREADS ARE NOT FULLY WIRED YET ───────────────────────
-		// Deliberately deferred until ring3 task bring-up. Two things here are
-		// known-incomplete, on purpose:
+		// ─── RING3 (user) THREADS ────────────────────────────────────────────────
+		// SS keeps the RPL-3 user data selector already set above — do NOT reassign
+		// it here without `| 3` (that exact bug shipped once: iretq to CPL 3 with an
+		// RPL-0 SS is a #GP).
 		//
-		// 1. EXIT PATH IS NOT SEEDED. Unlike the kernelThread branch above, we do
-		//    NOT seed a return address on the user stack. A ring3 _start that does
-		//    `ret` (GCC will NOT turn a C `return` into a syscall, so this is always
-		//    possible) will pop 0/garbage and fault. Seeding task_exit_with_retval
-		//    like the ring0 path would NOT help — it's a kernel address, and `ret`
-		//    to it from CPL 3 faults (#GP/#PF).
+		// RSP: top of the USER stack, minus the traditional 6-qword safety margin
+		// (matching the ring0 path), minus ONE more qword for the exit-trampoline
+		// return address that task_setup_ring3_exit_path() seeds at [RSP].  That
+		// seeded slot also gives _start the stack shape of a normal `call`
+		// (rsp%16==8 at entry), which compiled C fixtures are allowed to assume.
 		//
-		//    The correct fix (proven in the 32-bit OS — see
-		//    ~/src/os/kproj/chrisOSKernel/src/process.c: `processExit`, ~line 349):
-		//    seed regs.RSP with the VA of a small RING3 exit trampoline mapped
-		//    PAGE_USER into the task, e.g. `mov rax, SYS_exit; syscall`. On `ret`
-		//    the thread lands there in ring3 (a plain ring3→ring3 return, no fault),
-		//    and the syscall does the ring3→ring0 crossing cleanly. os64 has it
-		//    easier than the 32-bit version: argc/argv/env ride in RDI/RSI/RDX, so
-		//    there is no call frame to hand-craft — just one seeded return address.
+		// RSP0: top of the KERNEL stack — this is what the CPU (via TSS) and
+		// syscall_Enter (via CLS kernel_rsp0) load on every ring3→ring0 crossing,
+		// so it must be the ring0 stack, not the user one.  The -48 keeps it
+		// 16-byte aligned (stack tops are page-aligned), which syscall_Enter's
+		// frame math relies on.
 		//
-		// 2. REGISTER SETUP BELOW IS WRONG for a real user thread and must be fixed
-		//    in the same ring3 pass: RSP0 (the ring0 stack used on trap/syscall
-		//    entry) is set to the USER stack (esp3BaseV) instead of esp0BaseV, and
-		//    the offsets use THREAD_KERNEL_STACK_SIZE instead of THREAD_USER_STACK_SIZE.
-		//
-		// >> If you are chasing a #PF/#GP right after a ring3 task returns from
-		// >> _start — THIS is why. It is a missing feature, not a mystery. <<
-		newThread->regs.SS = GDT_USER_DATA_ENTRY << 3;
-		newThread->regs.RSP = newThread->esp3BaseV + THREAD_KERNEL_STACK_SIZE - sizeof(uintptr_t) * 6;
+		// The exit path itself (where a ring3 `ret` from _start lands) cannot be
+		// seeded here: the trampoline page isn't mapped until task_create() has
+		// built the task's address space.  See task_setup_ring3_exit_path().
+		newThread->regs.RSP = newThread->esp3BaseV + THREAD_USER_STACK_SIZE - sizeof(uintptr_t) * 6 - sizeof(uintptr_t);
 		newThread->regs.SS0 = GDT_KERNEL_DATA_ENTRY << 3;
-		newThread->regs.RSP0 = newThread->esp3BaseV + THREAD_KERNEL_STACK_SIZE - sizeof(uintptr_t) * 6;
+		newThread->regs.RSP0 = newThread->esp0BaseV + THREAD_KERNEL_STACK_SIZE - sizeof(uintptr_t) * 6;
 	}
 
 	newThread->regs.RFLAGS = 0x202;  //Interrupts enabled, reserved bit 1 set

--- a/kernel/src/tss.c
+++ b/kernel/src/tss.c
@@ -21,7 +21,10 @@ static void tss_install_descriptor(uint32_t cpu_index, tss_t *tss)
     uint64_t base = (uint64_t)tss;
     uint32_t limit = sizeof(tss_t) - 1;
     int descriptor = tss_descriptor_index(cpu_index);
-    set_gdt_entry(kGDT, descriptor, base, limit, GDT_ACCESS_TSS, 0x00, 1);
+    // GDT_S_SYSTEM_SEGMENT: a 64-bit TSS descriptor is 16 bytes — the upper
+    // half of the base lands in GDT entry descriptor+1 (reserved for it by
+    // tss_descriptor_index's 2-entry stride).
+    set_gdt_entry(kGDT, descriptor, base, limit, GDT_ACCESS_TSS, 0x00, GDT_S_SYSTEM_SEGMENT);
     kTSSSelector[cpu_index] = (uint16_t)(descriptor << 3);
 }
 

--- a/kernel/test/elf/Makefile
+++ b/kernel/test/elf/Makefile
@@ -1,6 +1,8 @@
 OUTPUT ?= ../../bin/test_elf
 DYN_OUTPUT ?= ../../bin/dyn_consumer
 ARG_OUTPUT ?= ../../bin/arg_echo
+SMOKE_OUTPUT ?= ../../bin/syscall_smoke
+RETEXIT_OUTPUT ?= ../../bin/exit_by_return
 LIBTEST ?= ../../bin/libtest.so
 
 CC ?= x86_64-elf-gcc
@@ -18,7 +20,9 @@ LDFLAGS ?= -static -nostdlib -T linker.ld -z max-page-size=0x1000
 # locals by pushing its exception frame right on top of them.
 # -masm=intel: all asm in this project — kernel and fixtures alike — is
 # Intel syntax (see outb in dyn_consumer.c).
-DYN_CFLAGS ?= -g -m64 -ffreestanding -fpie -mno-red-zone -fno-stack-protector -fcf-protection=none -nostdlib -nostartfiles -nodefaultlibs -masm=intel -Wall -Wextra
+# -mno-mmx/-mno-sse/-mno-sse2: SIMD is #UD until CR4.OSFXSR + FPU context
+# switching exist (see ARG_CFLAGS note).
+DYN_CFLAGS ?= -g -m64 -ffreestanding -fpie -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -fno-stack-protector -fcf-protection=none -nostdlib -nostartfiles -nodefaultlibs -masm=intel -Wall -Wextra
 # --hash-style=sysv pins the DT_HASH table the kernel's loader derives the
 # dynamic symbol count from (nchain). Bare-metal binutils defaults to sysv
 # today, but hosted targets default to gnu-only — pinning it costs nothing
@@ -31,12 +35,14 @@ DYN_LDFLAGS ?= -pie -z now -e _start --no-allow-shlib-undefined --hash-style=sys
 # hardening as dyn_consumer (-mno-red-zone etc.) because it runs with interrupts
 # enabled and can be preempted mid-function, and -masm=intel to match the
 # project-wide asm syntax convention.
-ARG_CFLAGS ?= -g -m64 -ffreestanding -fno-pic -fno-pie -mno-red-zone -fno-stack-protector -fcf-protection=none -nostdlib -nostartfiles -nodefaultlibs -masm=intel -Wall -Wextra
+# -mno-mmx/-mno-sse/-mno-sse2: CR4.OSFXSR is off, so SIMD is #UD even at
+# ring 3 — same rule as the kernel until the FPU-state slice enables it.
+ARG_CFLAGS ?= -g -m64 -ffreestanding -fno-pic -fno-pie -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -fno-stack-protector -fcf-protection=none -nostdlib -nostartfiles -nodefaultlibs -masm=intel -Wall -Wextra
 
 OBJS := serial_ping.o
 
 .PHONY: all
-all: $(OUTPUT) $(DYN_OUTPUT) $(ARG_OUTPUT)
+all: $(OUTPUT) $(DYN_OUTPUT) $(ARG_OUTPUT) $(SMOKE_OUTPUT) $(RETEXIT_OUTPUT)
 
 $(OUTPUT): $(OBJS)
 	@mkdir -p "$$(dirname $@)"
@@ -52,6 +58,23 @@ $(ARG_OUTPUT): arg_echo.o
 arg_echo.o: arg_echo.c
 	$(CC) $(ARG_CFLAGS) -c $< -o $@
 
+# The ring-3 syscall fixtures are static freestanding C like arg_echo, so they
+# share ARG_CFLAGS (-mno-red-zone matters even more here: these actually run
+# at CPL 3 with interrupts enabled and WILL be preempted).
+$(SMOKE_OUTPUT): syscall_smoke.o
+	@mkdir -p "$$(dirname $@)"
+	$(LD) $(LDFLAGS) -o $@ syscall_smoke.o
+
+syscall_smoke.o: syscall_smoke.c
+	$(CC) $(ARG_CFLAGS) -c $< -o $@
+
+$(RETEXIT_OUTPUT): exit_by_return.o
+	@mkdir -p "$$(dirname $@)"
+	$(LD) $(LDFLAGS) -o $@ exit_by_return.o
+
+exit_by_return.o: exit_by_return.c
+	$(CC) $(ARG_CFLAGS) -c $< -o $@
+
 $(DYN_OUTPUT): dyn_consumer.o $(LIBTEST)
 	@mkdir -p "$$(dirname $@)"
 	$(LD) $(DYN_LDFLAGS) -o $@ dyn_consumer.o $(LIBTEST)
@@ -61,4 +84,4 @@ dyn_consumer.o: dyn_consumer.c
 
 .PHONY: clean
 clean:
-	rm -f $(OBJS) $(OUTPUT) dyn_consumer.o $(DYN_OUTPUT) arg_echo.o $(ARG_OUTPUT)
+	rm -f $(OBJS) $(OUTPUT) dyn_consumer.o $(DYN_OUTPUT) arg_echo.o $(ARG_OUTPUT) syscall_smoke.o $(SMOKE_OUTPUT) exit_by_return.o $(RETEXIT_OUTPUT)

--- a/kernel/test/elf/exit_by_return.c
+++ b/kernel/test/elf/exit_by_return.c
@@ -1,0 +1,22 @@
+// exit_by_return.c — ring-3 exit-trampoline fixture.
+//
+// The whole program is one statement: return a magic value from _start.
+// That exercises the path syscall_smoke.c deliberately avoids: a compiled C
+// `ret` at CPL 3 pops the return address task_setup_ring3_exit_path() seeded
+// on the user stack, lands in the trampoline page at TASK_EXIT_TRAMPOLINE_VIRT
+// (still ring 3), which moves RAX into RDI and invokes SYSCALL_EXIT.  The
+// kernel-side test asserts task->retVal == EXIT_BY_RETURN_MAGIC — the value
+// can only have traveled RAX -> trampoline -> exit syscall -> task->retVal.
+//
+// If this fixture faults instead of exiting, the seeded return address or the
+// trampoline mapping is broken (see thread.c ring3 branch + task.c
+// task_setup_ring3_exit_path).
+
+unsigned long _start(unsigned long argc, char **argv, char **env)
+{
+    (void)argc;
+    (void)argv;
+    (void)env;
+
+    return 0x2E7BEA57UL;   // "RET BEAST" — matched by test_ring3_exit_by_return
+}

--- a/kernel/test/elf/syscall_smoke.c
+++ b/kernel/test/elf/syscall_smoke.c
@@ -1,0 +1,88 @@
+// syscall_smoke.c — first true ring-3 fixture: SYSCALL/SYSRET round trip,
+// write() to the console, and an explicit exit() syscall.
+//
+// The kernel launches this as /bin/syscall_smoke with isKernelTask=false, so
+// unlike every fixture before it, this one actually runs at CPL 3 and crosses
+// the privilege boundary through syscall_Enter/sysretq.  It exercises, in
+// order:
+//   1. SYSCALL_YIELD    — the simplest possible round trip (no pointer args,
+//                         no CR3 switch).  If STAR/GDT are wrong, we die at
+//                         the first sysret, right here, with nothing else in
+//                         the picture.
+//   2. SYSCALL_WRITE    — user pointer validated + copied under the user CR3,
+//                         printed to the console under the kernel CR3.  The
+//                         return value must equal the byte count sent.
+//   3. SYSCALL_EXIT     — explicit exit; the kernel-side test asserts
+//                         task->retVal == SMOKE_OK, which can ONLY have got
+//                         there through the exit syscall (this _start never
+//                         returns, so the ret-trampoline path can't set it).
+//
+// Failures return a distinct 0xE51Cxxxx code via exit() (or via `return`,
+// where the exit trampoline turns RAX into the same retVal) so a regression
+// pinpoints the step that broke.
+//
+// The syscall stubs below are the embryo of the userland syscall layer:
+// os64's convention is RAX=number, args in RDI/RSI/RDX/R10/R8/R9, result in
+// RAX; RCX/R11 are burned by the hardware and the kernel clobbers only what a
+// C call would (see syscall.S), so a simple "syscall" instruction with the
+// right register constraints is a complete stub.
+
+#include <stdint.h>
+
+// Must match kernel/include/syscall_numbers.h.
+#define SYSCALL_YIELD      0
+#define SYSCALL_EXIT       2
+#define SYSCALL_WRITE      3
+#define CONSOLE_OUT        1
+
+#define SMOKE_OK           0x0005E00DUL   // "SGOOD" — all checks passed
+#define FAIL_YIELD         0xE51C0001UL   // yield returned an error
+#define FAIL_WRITE_RET     0xE51C0002UL   // write returned wrong byte count
+
+static inline uint64_t os64_syscall0(uint64_t nr)
+{
+    uint64_t ret;
+    __asm__ volatile("syscall"
+                     : "=a"(ret)
+                     : "a"(nr)
+                     : "rcx", "r11", "memory");
+    return ret;
+}
+
+static inline uint64_t os64_syscall3(uint64_t nr, uint64_t a0, uint64_t a1, uint64_t a2)
+{
+    uint64_t ret;
+    __asm__ volatile("syscall"
+                     : "=a"(ret)
+                     : "a"(nr), "D"(a0), "S"(a1), "d"(a2)
+                     : "rcx", "r11", "memory");
+    return ret;
+}
+
+// Freestanding — no libc, so no strlen; the message length is compile-time.
+static const char kMessage[] = "hello from ring 3 via write()\n";
+#define MESSAGE_LEN (sizeof(kMessage) - 1)
+
+unsigned long _start(unsigned long argc, char **argv, char **env)
+{
+    (void)argc;
+    (void)argv;
+    (void)env;
+
+    // 1. Prove the bare SYSCALL/SYSRET round trip survives.
+    if (os64_syscall0(SYSCALL_YIELD) != 0)
+        return FAIL_YIELD;
+
+    // 2. Prove pointer-carrying syscalls work end to end.
+    uint64_t written = os64_syscall3(SYSCALL_WRITE, CONSOLE_OUT,
+                                     (uint64_t)kMessage, MESSAGE_LEN);
+    if (written != MESSAGE_LEN)
+        os64_syscall3(SYSCALL_EXIT, FAIL_WRITE_RET, 0, 0);
+
+    // 3. Explicit exit with the success sentinel.  Never returns.
+    os64_syscall3(SYSCALL_EXIT, SMOKE_OK, 0, 0);
+
+    // Unreachable — but if exit somehow returned, fall back to the trampoline
+    // path so the kernel still sees a distinctive failure code.
+    return 0xE51CDEADUL;
+}

--- a/kernel/test/shlib/Makefile
+++ b/kernel/test/shlib/Makefile
@@ -10,7 +10,9 @@ LD ?= x86_64-elf-ld
 # its frame starting AT the current RSP — directly into those red-zone
 # locals — silently corrupting them. Matches the kernel's own CFLAGS for
 # exactly this reason.
-CFLAGS ?= -g -m64 -ffreestanding -fPIC -mno-red-zone -fno-stack-protector -fcf-protection=none -nostdlib -nostartfiles -nodefaultlibs -Wall -Wextra
+# -mno-mmx/-mno-sse/-mno-sse2: SIMD is #UD until CR4.OSFXSR + FPU context
+# switching exist (see test/elf/Makefile's ARG_CFLAGS note).
+CFLAGS ?= -g -m64 -ffreestanding -fPIC -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -fno-stack-protector -fcf-protection=none -nostdlib -nostartfiles -nodefaultlibs -Wall -Wextra
 # NOTE: -shared is NOT passed to $(CC) here — this cross toolchain's specs
 # were built without shared-library support and silently drop it before the
 # link step ever happens (confirmed via `gcc -### -shared ...`). Compiling

--- a/kernel/test/test_main.c
+++ b/kernel/test/test_main.c
@@ -1,4 +1,5 @@
 #include "test_framework.h"
+#include "panic.h"
 
 #include "memory/kmalloc.h"
 #include "memory/memset.h"
@@ -869,6 +870,90 @@ static bool test_dynamic_linking(void)
     return true;
 }
 
+// ── ring-3 / syscall tests ───────────────────────────────────────────────────
+// These are the first tests to launch a task with isKernelTask=false — actual
+// CPL 3 execution, crossing back and forth through syscall_Enter/sysretq.
+// Everything before them ran ELF fixtures at ring 0.
+
+// Success sentinel syscall_smoke.c exits with after yield + write + explicit
+// exit all succeed.  Failures exit with 0xE51Cxxxx codes identifying the step.
+#define SYSCALL_SMOKE_RETVAL 0x0005E00DUL
+
+static bool test_ring3_syscall_smoke(void)
+{
+    if (kRootFilesystem == NULL) {
+        printd(DEBUG_TESTS, "\tSKIP: test_ring3_syscall_smoke (no root filesystem mounted)\n");
+        return true;
+    }
+
+    task_t *task = task_create("/bin/syscall_smoke", 0, NULL, kKernelTask, false, THREAD_NO_AFFINITY);
+    if (task == NULL) {
+        printd(DEBUG_TESTS, "\tFAIL: test_ring3_syscall_smoke - task_create returned NULL\n");
+        return false;
+    }
+
+    scheduler_submit_new_task(task);
+
+    // Poll until the task exits or we time out (~1 second at 100 ticks/sec).
+    for (int i = 0; i < 100 && !task->exited; i++)
+        wait(10);
+
+    if (!task->exited) {
+        printd(DEBUG_TESTS, "\tFAIL: test_ring3_syscall_smoke - task did not exit within 1 second "
+               "(likely died crossing ring 3 <-> ring 0; check STAR/GDT/sysret)\n");
+        return false;
+    }
+
+    if (task->retVal != SYSCALL_SMOKE_RETVAL) {
+        printd(DEBUG_TESTS, "\tFAIL: test_ring3_syscall_smoke - retVal=0x%lx, expected 0x%lx "
+               "(0xE51Cxxxx identifies the failed step)\n",
+               task->retVal, (uint64_t)SYSCALL_SMOKE_RETVAL);
+        return false;
+    }
+
+    printd(DEBUG_TESTS, "\tPASS: test_ring3_syscall_smoke (ring3 launch, yield, write, explicit exit)\n");
+    return true;
+}
+
+// exit_by_return.c just `return`s this from _start; it can only reach retVal
+// via the seeded user-stack return address -> ring-3 exit trampoline ->
+// SYSCALL_EXIT chain, so this asserts that whole path.
+#define EXIT_BY_RETURN_MAGIC 0x2E7BEA57UL
+
+static bool test_ring3_exit_by_return(void)
+{
+    if (kRootFilesystem == NULL) {
+        printd(DEBUG_TESTS, "\tSKIP: test_ring3_exit_by_return (no root filesystem mounted)\n");
+        return true;
+    }
+
+    task_t *task = task_create("/bin/exit_by_return", 0, NULL, kKernelTask, false, THREAD_NO_AFFINITY);
+    if (task == NULL) {
+        printd(DEBUG_TESTS, "\tFAIL: test_ring3_exit_by_return - task_create returned NULL\n");
+        return false;
+    }
+
+    scheduler_submit_new_task(task);
+
+    for (int i = 0; i < 100 && !task->exited; i++)
+        wait(10);
+
+    if (!task->exited) {
+        printd(DEBUG_TESTS, "\tFAIL: test_ring3_exit_by_return - task did not exit within 1 second "
+               "(trampoline seed or mapping broken? see task_setup_ring3_exit_path)\n");
+        return false;
+    }
+
+    if (task->retVal != EXIT_BY_RETURN_MAGIC) {
+        printd(DEBUG_TESTS, "\tFAIL: test_ring3_exit_by_return - retVal=0x%lx, expected 0x%lx\n",
+               task->retVal, (uint64_t)EXIT_BY_RETURN_MAGIC);
+        return false;
+    }
+
+    printd(DEBUG_TESTS, "\tPASS: test_ring3_exit_by_return (ret -> trampoline -> exit syscall)\n");
+    return true;
+}
+
 // ── env tests ────────────────────────────────────────────────────────────────
 
 static bool test_env_create_empty(void)
@@ -1087,6 +1172,8 @@ static void register_builtin_tests(void)
     test_register("elf_loader", test_elf_loader, TEST_PHASE_POSTBOOT);
     test_register("task_args", test_task_args, TEST_PHASE_POSTBOOT);
     test_register("dynamic_linking", test_dynamic_linking, TEST_PHASE_POSTBOOT);
+    test_register("ring3_syscall_smoke", test_ring3_syscall_smoke, TEST_PHASE_POSTBOOT);
+    test_register("ring3_exit_by_return", test_ring3_exit_by_return, TEST_PHASE_POSTBOOT);
 }
 
 void test_framework_init(void)
@@ -1137,10 +1224,11 @@ static void test_run_phase(int phase, const char *label)
     printd(DEBUG_TESTS, "BUILT-IN TESTS: %u passed, %u failed\n", (unsigned int)passed, (unsigned int)failed);
 
     if (failed > 0) {
-        printd(DEBUG_TESTS, "Test framework detected failures. System halted.\n");
-        for (;;) {
-            __asm__ volatile ("cli; hlt");
-        }
+        // panic(), not a bare cli/hlt: panic force-drains the log buffer to
+        // serial before halting.  The old halt stranded this message — and any
+        // test results logd hadn't drained yet — in the ring buffer forever.
+        panic("Test framework: %u %s test(s) failed. System halted.\n",
+              (unsigned int)failed, label);
     }
 }
 

--- a/utility/os64_symbols.gdb
+++ b/utility/os64_symbols.gdb
@@ -1,0 +1,92 @@
+# os64 shared GDB setup — sourced by BOTH ./.gdbinit (CLI gdb) and
+# .vscode/launch.json setupCommands (VS Code cppdbg), so app-symbol
+# autoloading behaves identically everywhere.  Keep session-specific stuff
+# (target remote, kernel symbol-file, personal breakpoints) OUT of this file.
+
+# add-symbol-file normally asks "y or n"; under VS Code's MI console prompts
+# can't be answered ("input not from terminal") and get auto-declined, which
+# silently throws breakpoints away.  Never prompt.
+set confirm off
+
+# Breakpoints named before their program's symbols exist should wait for the
+# symbols instead of failing (they resolve the moment the autoloader below
+# add-symbol-file's the app).
+set breakpoint pending on
+
+# ── Automatic per-program symbol loading ─────────────────────────────────────
+# The kernel calls debug_task_loaded(path, load_bias) every time it finishes
+# loading a program image (task.c).  The silent breakpoint below fires there,
+# reads the arguments, add-symbol-file's kernel/bin/<basename> (offset by the
+# load bias for PIE binaries), and resumes without stopping.  Every app's
+# debug info is available the moment the OS creates the task — no manual
+# loading, no unique-link-address tricks; all binaries happily at 0x400000.
+python
+import gdb, os
+
+# Every os64 program links at the same base (0x400000), so keeping several
+# apps' symbol files loaded at once makes GDB's address->symbol lookup a coin
+# flip: a stop in one app gets LABELED with another app's function (observed:
+# a hit on syscall_smoke's _start displayed as "streq at arg_echo.c:64").
+# Since debugging is one-app-at-a-time in practice, the autoloader keeps ONLY
+# the most recently loaded app's symbols: previous ones are removed when a new
+# program loads.  Breakpoints against a not-yet-loaded (or unloaded) app
+# simply go pending and resolve when it (re)appears.
+class Os64SymbolAutoload(gdb.Breakpoint):
+    def __init__(self):
+        super(Os64SymbolAutoload, self).__init__("debug_task_loaded", internal=True)
+        self.silent = True
+        self.current = None      # (abspath, bias) of the app symbols now loaded
+
+    def stop(self):
+        try:
+            # Read the kernel-image GLOBALS, not function arguments — globals
+            # live at fixed, always-mapped kernel addresses, so this works
+            # under any CR3 and any frame state (argument parsing did not).
+            path = gdb.parse_and_eval("kDebugTaskLoadedPath").string()
+            bias = int(gdb.parse_and_eval("kDebugTaskLoadedBias"))
+            name = os.path.basename(path)
+            symfile = os.path.abspath(os.path.join("kernel", "bin", name))
+            key = (symfile, bias)
+            if key != self.current and os.path.exists(symfile):
+                if self.current is not None:
+                    gdb.execute("remove-symbol-file %s" % self.current[0],
+                                to_string=True)
+                cmd = "add-symbol-file %s" % symfile
+                if bias:
+                    cmd += " -o %#x" % bias
+                gdb.execute(cmd, to_string=True)
+                self.current = key
+                gdb.write("[os64] symbols: %s%s\n"
+                          % (symfile, (" (+%#x)" % bias) if bias else ""))
+        except Exception as exc:
+            gdb.write("[os64] symbol autoload failed: %s\n" % exc)
+        return False    # never actually stop here
+
+Os64SymbolAutoload()
+
+# $os64_app() — convenience function returning the exename of the task the
+# CURRENT GDB THREAD's CPU is running ("/syscall_smoke", "/logd", ...).  Goes
+# through the kernel's own kCoreLocalStorage array indexed by CPU (gdb thread
+# N == CPU N-1 under QEMU) rather than $gs_base, which not every QEMU/gdb
+# combination exposes — and a breakpoint condition that ERRORS makes gdb stop
+# anyway, silently defeating the filter.  Use it to make an address breakpoint
+# fire for ONE app even where apps' link addresses overlap:
+#     hbreak syscall_smoke.c:_start if $_streq($os64_app(), "/syscall_smoke")
+class Os64App(gdb.Function):
+    def __init__(self):
+        super(Os64App, self).__init__("os64_app")
+
+    def invoke(self):
+        try:
+            cpu = gdb.selected_thread().num - 1
+            cls = gdb.parse_and_eval(
+                "((core_local_storage_t *)kCoreLocalStorage)[%d]" % cpu)
+            task = cls["task"]
+            if int(task) == 0:
+                return ""
+            return task["exename"].string()
+        except Exception:
+            return ""
+
+Os64App()
+end


### PR DESCRIPTION
os64 now launches, runs, and cleanly exits genuine ring-3 programs. New syscalls: exit and write (console), joining yield and debug_log. Two ring-3 fixtures (syscall_smoke, exit_by_return) run in the post-boot test suite, covering the explicit-exit and return-through-trampoline paths end to end.

Syscall path:
- Fix STAR: user selector belongs in bits 63:48 (was in the dead 31:16 legacy-EIP field); reorder user GDT entries (data 7, code 8) to satisfy SYSRETQ's hardwired SS=base+8/CS=base+16 layout, with static asserts
- Enable EFER.SCE per core (syscall was #UD without it)
- Rewrite syscall_Enter: never touches the user stack (bogus ring-3 RSP can no longer fault the kernel), stashes user RSP in a new CLS scratch slot, marshals args in asm straight into _syscall_dispatch (removes the register-pinned-locals UB)
- Per-entry user-pointer argument mask replaces the blanket 6-arg range check, which rejected valid calls over ring-3 garbage in unused arg regs
- Drop the needs_cr3_switch usage: handlers run on the caller's CR3 (kernel upper half is shared into every task PML4); switching CR3 under a C handler unmapped its own task-local stack and triple-faulted
- CR3 exit tripwire in the dispatcher (a keeper from the 32-bit OS)

Ring-3 task plumbing:
- createThread: fix user thread RSP0/RSP (kernel stack for RSP0, user stack sizes, preserve SS RPL 3); seed a ring-3 exit trampoline page (read-only+exec at TASK_EXIT_TRAMPOLINE_VIRT) so a plain `ret` from _start becomes an exit syscall with RAX as the exit code
- paging: propagate PAGE_USER to intermediate table entries (a user fetch through a USER-less PDE faults even when the PTE allows it)
- Ban SIMD in kernel and fixtures (-mno-mmx/-mno-sse/-mno-sse2): CR4.OSFXSR is off and the scheduler doesn't save XMM state yet

Scheduler:
- Save RSP (and SS) from the interrupt frame's +24/+32 fields, read before the CR3 switch, instead of frame-base+40 arithmetic: the CPU aligns RSP down to 16 bytes before pushing a frame, so +40 loses the remainder (up to 15 bytes of stack per preemption, masked for years by -O0 leave/ret)
- THREAD_KERNEL_STACK_SIZE 0xFFFF -> 0x10000: an odd stack size made every kernel RSP odd, maximizing that alignment loss
- Keep interrupts masked in _schedule_ap until mp_inScheduler is set
- Unify the ring0/ring3 return paths through one 5-QWORD iretq frame; retire the retfq path that left ring 3 running with IF=0
- Retire scheduler_yield/scheduler_invoke_vector: every scheduler entry is now a real LAPIC interrupt (timer or scheduler_trigger's self-IPI); the software `int` entry bypassed APIC nesting protection

Fixes to bugs found along the way:
- set_gdt_entry treated its S-flag argument as inverted, so every code/data entry zeroed its successor GDT entry (latent while init order was ascending; fatal after the user-entry swap)
- exception_panic now writes directly to serial (screen-only panics were invisible headless; the ring-buffer drain is only best-effort)
- Test framework failures panic (with log drain) instead of silent cli/hlt
- Protection-violation panic decodes the error code instead of assuming write-to-read-only

Debugging QoL: kernel notifies GDB of each program load via debug_task_loaded globals; utility/os64_symbols.gdb (shared by .gdbinit and VS Code) auto-loads each app's symbols, keeps only the most recent (all apps share a link address), and provides $os64_app() for task-conditional breakpoints.